### PR TITLE
Suppress dirty submodules in VSCode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,8 +16,10 @@
             "settings": {
                 "git.ignoredRepositories": [
                     "libdragon",
+                    "src/libs/libspng",
                     "src/libs/mini.c",
-                    "src/libs/minimp3"
+                    "src/libs/minimp3",
+                    "src/libs/miniz.c"
                 ]
             }
         }

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,15 +2,20 @@
 	path = libdragon
 	url = https://github.com/DragonMinded/libdragon
 	branch = unstable
+	ignore = dirty
 [submodule "src/libs/libspng"]
 	path = src/libs/libspng
 	url = https://github.com/randy408/libspng.git
+	ignore = dirty
 [submodule "src/libs/mini.c"]
 	path = src/libs/mini.c
 	url = https://github.com/univrsal/mini.c.git
+	ignore = dirty
 [submodule "src/libs/minimp3"]
 	path = src/libs/minimp3
 	url = https://github.com/lieff/minimp3.git
+	ignore = dirty
 [submodule "src/libs/miniz"]
 	path = src/libs/miniz
 	url = https://github.com/richgel999/miniz.git
+	ignore = dirty


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When running in a dev container, certain submodules show changes in VSCode.
GitHub Desktop does not show them.

This PR also adds missing Submodules to the devcontainer.json git.ignoredRepositories.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->
Speculative fix. If there is a better way, it is welcome!

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
