### PR TITLE
Add ability to force tv region based on detected ROM

### DIFF
--- a/src/menu/settings.c
+++ b/src/menu/settings.c
@@ -18,7 +18,7 @@ static settings_t init = {
     .bgm_enabled = false,
     .sound_enabled = false,
     .rumble_enabled = false,
-    .detect_rom_region_enabled = true,
+    .autodetect_rom_region = true,
 };
 
 
@@ -33,12 +33,12 @@ void settings_load (settings_t *settings) {
     settings->hidden_files_enabled = mini_get_bool(ini, "menu", "show_hidden_files", init.hidden_files_enabled);
     settings->default_directory = strdup(mini_get_string(ini, "menu", "default_directory", init.default_directory));
     settings->use_saves_folder = mini_get_bool(ini, "menu", "use_saves_folder", init.use_saves_folder);
+    settings->autodetect_rom_region = mini_get_bool(ini, "menu", "autodetect_rom_region", init.autodetect_rom_region);
 
     /* Beta feature flags, they might not be in the file */
     settings->bgm_enabled = mini_get_bool(ini, "menu_beta_flag", "bgm_enabled", init.bgm_enabled);
     settings->sound_enabled = mini_get_bool(ini, "menu_beta_flag", "sound_enabled", init.sound_enabled);
     settings->rumble_enabled = mini_get_bool(ini, "menu_beta_flag", "rumble_enabled", init.rumble_enabled);
-    settings->detect_rom_region_enabled = mini_get_bool(ini, "menu_beta_flag", "detect_rom_region_enabled", init.detect_rom_region_enabled);
 
 
     mini_free(ini);
@@ -51,12 +51,12 @@ void settings_save (settings_t *settings) {
     mini_set_bool(ini, "menu", "show_hidden_files", settings->hidden_files_enabled);
     mini_set_string(ini, "menu", "default_directory", settings->default_directory);
     mini_set_bool(ini, "menu", "use_saves_folder", settings->use_saves_folder);
+    mini_set_bool(ini, "menu", "autodetect_rom_region", settings->autodetect_rom_region);
 
     /* Beta feature flags, they should not save until production ready! */
-    // mini_set_bool(ini, "menu_beta_flag", "bgm_enabled", init.bgm_enabled);
-    // mini_set_bool(ini, "menu_beta_flag", "sound_enabled", init.sound_enabled);
-    // mini_set_bool(ini, "menu_beta_flag", "rumble_enabled", init.rumble_enabled);
-    // mini_set_bool(ini, "menu_beta_flag", "detect_rom_region_enabled", init.detect_rom_region_enabled;
+    // mini_set_bool(ini, "menu_beta_flag", "bgm_enabled", settings->bgm_enabled);
+    // mini_set_bool(ini, "menu_beta_flag", "sound_enabled", settings->sound_enabled);
+    // mini_set_bool(ini, "menu_beta_flag", "rumble_enabled", settings->rumble_enabled);
 
     mini_save(ini, MINI_FLAGS_SKIP_EMPTY_GROUPS);
 

--- a/src/menu/settings.c
+++ b/src/menu/settings.c
@@ -14,10 +14,11 @@ static settings_t init = {
     .default_directory = "/",
     .use_saves_folder = true,
 
-    /* Beta feature flags */
+    /* Beta feature flags (should always init to off) */
     .bgm_enabled = false,
     .sound_enabled = false,
-    .rumble_enabled = true,
+    .rumble_enabled = false,
+    .detect_rom_region_enabled = true,
 };
 
 
@@ -37,6 +38,7 @@ void settings_load (settings_t *settings) {
     settings->bgm_enabled = mini_get_bool(ini, "menu_beta_flag", "bgm_enabled", init.bgm_enabled);
     settings->sound_enabled = mini_get_bool(ini, "menu_beta_flag", "sound_enabled", init.sound_enabled);
     settings->rumble_enabled = mini_get_bool(ini, "menu_beta_flag", "rumble_enabled", init.rumble_enabled);
+    settings->detect_rom_region_enabled = mini_get_bool(ini, "menu_beta_flag", "detect_rom_region_enabled", init.detect_rom_region_enabled);
 
 
     mini_free(ini);
@@ -54,6 +56,7 @@ void settings_save (settings_t *settings) {
     // mini_set_bool(ini, "menu_beta_flag", "bgm_enabled", init.bgm_enabled);
     // mini_set_bool(ini, "menu_beta_flag", "sound_enabled", init.sound_enabled);
     // mini_set_bool(ini, "menu_beta_flag", "rumble_enabled", init.rumble_enabled);
+    // mini_set_bool(ini, "menu_beta_flag", "detect_rom_region_enabled", init.detect_rom_region_enabled;
 
     mini_save(ini, MINI_FLAGS_SKIP_EMPTY_GROUPS);
 

--- a/src/menu/settings.c
+++ b/src/menu/settings.c
@@ -13,12 +13,12 @@ static settings_t init = {
     .hidden_files_enabled = false,
     .default_directory = "/",
     .use_saves_folder = true,
+    .autodetect_rom_region = true,
 
     /* Beta feature flags (should always init to off) */
     .bgm_enabled = false,
     .sound_enabled = false,
     .rumble_enabled = false,
-    .autodetect_rom_region = true,
 };
 
 

--- a/src/menu/settings.h
+++ b/src/menu/settings.h
@@ -22,6 +22,9 @@ typedef struct {
     /** @brief Put saves into separate directory */
     bool use_saves_folder;
 
+    /** @brief Enable forcing the (N64 system region) tv type to align with game region when booting the ROM. */
+    bool autodetect_rom_region;
+
     /** @brief Enable Background music */
     bool bgm_enabled;
 
@@ -30,9 +33,6 @@ typedef struct {
 
     /** @brief Enable rumble feedback */
     bool rumble_enabled;
-
-    /** @brief Enable forcing the (N64 system region) tv type to align with game region when booting the ROM. */
-    bool detect_rom_region_enabled;
 
 } settings_t;
 

--- a/src/menu/settings.h
+++ b/src/menu/settings.h
@@ -31,6 +31,9 @@ typedef struct {
     /** @brief Enable rumble feedback */
     bool rumble_enabled;
 
+    /** @brief Enable forcing the (N64 system region) tv type to align with game region when booting the ROM. */
+    bool detect_rom_region_enabled;
+
 } settings_t;
 
 /** @brief The settings to load */

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -206,7 +206,15 @@ static void load (menu_t *menu) {
 
     menu->next_mode = MENU_MODE_BOOT;
     menu->boot_params->device_type = BOOT_DEVICE_TYPE_ROM;
+    // FIXME: If the setting `detect_rom_region_enabled` is not enabled, use BOOT_TV_TYPE_PASSTHROUGH
     menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
+    // Else check the market type (menu->load.rom_info.destination_code) and set best guess?!
+    // If the guess is NTSC, use BOOT_TV_TYPE_NTSC
+    // If the guess is PAL, use BOOT_TV_TYPE_PAL
+    // If the guess is MPAL, use BOOT_TV_TYPE_MPAL
+    // There might be some interesting errors with OTHER_X and OTHER_Y (e.g. TGR Asia), but otherwise fine.
+
+
     menu->boot_params->detect_cic_seed = true;
 }
 

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -208,7 +208,7 @@ static void load (menu_t *menu) {
     menu->boot_params->device_type = BOOT_DEVICE_TYPE_ROM;
     menu->boot_params->detect_cic_seed = true;
     
-    if (menu->settings.detect_rom_region_enabled) {
+    if (menu->settings.autodetect_rom_region) {
         // check the market type (menu->load.rom_info.destination_code) and set best guess?!
         switch (menu->load.rom_info.destination_code) {
             case MARKET_NORTH_AMERICA:

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -127,10 +127,11 @@ static boot_tv_type_t determine_tv_boot_type (destination_type_t rom_destination
             case MARKET_GATEWAY64_PAL:
             case MARKET_EUROPEAN_BASIC:
             // FIXME: There might be some interesting errors with OTHER_X and OTHER_Y (e.g. TGR Asia).
+            // But they are mainly PAL regions.
             case MARKET_OTHER_X:
             case MARKET_OTHER_Y:
                 return BOOT_TV_TYPE_PAL;
-            // FIXME: We cannot be sure on these markets, so just return the default!
+            // FIXME: We cannot be sure on these markets, so just return the default for the moment!
             case MARKET_CHINESE:
             case MARKET_CANADIAN:
             case MARKET_KOREAN:
@@ -248,8 +249,6 @@ static void load (menu_t *menu) {
     else {
         menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
     }
-    
-
 }
 
 static void deinit (void) {

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -139,7 +139,6 @@ static boot_tv_type_t determine_tv_boot_type (destination_type_t rom_destination
             default: 
                 return BOOT_TV_TYPE_PASSTHROUGH;
         }
-
 }
 
 

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -208,42 +208,45 @@ static void load (menu_t *menu) {
     menu->boot_params->device_type = BOOT_DEVICE_TYPE_ROM;
     menu->boot_params->detect_cic_seed = true;
     
-    // FIXME: If the setting `detect_rom_region_enabled` is not enabled, use BOOT_TV_TYPE_PASSTHROUGH
-    //if (detect_rom_region_enabled) {
-    //menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
-    // check the market type (menu->load.rom_info.destination_code) and set best guess?!
-    switch (menu->load.rom_info.destination_code) {
-        case MARKET_NORTH_AMERICA:
-        case MARKET_JAPANESE:
-        case MARKET_JAPANESE_MULTI:
-        case MARKET_GATEWAY64_NTSC:
-            menu->boot_params->tv_type = BOOT_TV_TYPE_NTSC;
-            break;
-        case MARKET_BRAZILIAN:
-            menu->boot_params->tv_type = BOOT_TV_TYPE_MPAL;
-            break;
-        case MARKET_GERMAN:
-        case MARKET_FRENCH:
-        case MARKET_DUTCH:
-        case MARKET_ITALIAN:
-        case MARKET_SPANISH:
-        case MARKET_AUSTRALIAN:
-        case MARKET_SCANDINAVIAN:  
-        case MARKET_GATEWAY64_PAL:
-        case MARKET_EUROPEAN_BASIC:
-        // FIXME: There might be some interesting errors with OTHER_X and OTHER_Y (e.g. TGR Asia).
-        case MARKET_OTHER_X:
-        case MARKET_OTHER_Y:
-            menu->boot_params->tv_type = BOOT_TV_TYPE_PAL;
-            break;
-        // FIXME: We cannot be sure on these markets, so just return the default!
-        case MARKET_CHINESE:
-        case MARKET_CANADIAN:
-        case MARKET_KOREAN:
-        case MARKET_OTHER_Z:
-        default: 
-            menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
-            break;
+    if (menu->settings.detect_rom_region_enabled) {
+        // check the market type (menu->load.rom_info.destination_code) and set best guess?!
+        switch (menu->load.rom_info.destination_code) {
+            case MARKET_NORTH_AMERICA:
+            case MARKET_JAPANESE:
+            case MARKET_JAPANESE_MULTI:
+            case MARKET_GATEWAY64_NTSC:
+                menu->boot_params->tv_type = BOOT_TV_TYPE_NTSC;
+                break;
+            case MARKET_BRAZILIAN:
+                menu->boot_params->tv_type = BOOT_TV_TYPE_MPAL;
+                break;
+            case MARKET_GERMAN:
+            case MARKET_FRENCH:
+            case MARKET_DUTCH:
+            case MARKET_ITALIAN:
+            case MARKET_SPANISH:
+            case MARKET_AUSTRALIAN:
+            case MARKET_SCANDINAVIAN:  
+            case MARKET_GATEWAY64_PAL:
+            case MARKET_EUROPEAN_BASIC:
+            // FIXME: There might be some interesting errors with OTHER_X and OTHER_Y (e.g. TGR Asia).
+            case MARKET_OTHER_X:
+            case MARKET_OTHER_Y:
+                menu->boot_params->tv_type = BOOT_TV_TYPE_PAL;
+                break;
+            // FIXME: We cannot be sure on these markets, so just return the default!
+            case MARKET_CHINESE:
+            case MARKET_CANADIAN:
+            case MARKET_KOREAN:
+            case MARKET_OTHER_Z:
+            default: 
+                menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
+                break;
+        }
+
+    }
+    else {
+        menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
     }
     
 

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -206,16 +206,47 @@ static void load (menu_t *menu) {
 
     menu->next_mode = MENU_MODE_BOOT;
     menu->boot_params->device_type = BOOT_DEVICE_TYPE_ROM;
-    // FIXME: If the setting `detect_rom_region_enabled` is not enabled, use BOOT_TV_TYPE_PASSTHROUGH
-    menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
-    // Else check the market type (menu->load.rom_info.destination_code) and set best guess?!
-    // If the guess is NTSC, use BOOT_TV_TYPE_NTSC
-    // If the guess is PAL, use BOOT_TV_TYPE_PAL
-    // If the guess is MPAL, use BOOT_TV_TYPE_MPAL
-    // There might be some interesting errors with OTHER_X and OTHER_Y (e.g. TGR Asia), but otherwise fine.
-
-
     menu->boot_params->detect_cic_seed = true;
+    
+    // FIXME: If the setting `detect_rom_region_enabled` is not enabled, use BOOT_TV_TYPE_PASSTHROUGH
+    //if (detect_rom_region_enabled) {
+    //menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
+    // check the market type (menu->load.rom_info.destination_code) and set best guess?!
+    switch (menu->load.rom_info.destination_code) {
+        case MARKET_NORTH_AMERICA:
+        case MARKET_JAPANESE:
+        case MARKET_JAPANESE_MULTI:
+        case MARKET_GATEWAY64_NTSC:
+            menu->boot_params->tv_type = BOOT_TV_TYPE_NTSC;
+            break;
+        case MARKET_BRAZILIAN:
+            menu->boot_params->tv_type = BOOT_TV_TYPE_MPAL;
+            break;
+        case MARKET_GERMAN:
+        case MARKET_FRENCH:
+        case MARKET_DUTCH:
+        case MARKET_ITALIAN:
+        case MARKET_SPANISH:
+        case MARKET_AUSTRALIAN:
+        case MARKET_SCANDINAVIAN:  
+        case MARKET_GATEWAY64_PAL:
+        case MARKET_EUROPEAN_BASIC:
+        // FIXME: There might be some interesting errors with OTHER_X and OTHER_Y (e.g. TGR Asia).
+        case MARKET_OTHER_X:
+        case MARKET_OTHER_Y:
+            menu->boot_params->tv_type = BOOT_TV_TYPE_PAL;
+            break;
+        // FIXME: We cannot be sure on these markets, so just return the default!
+        case MARKET_CHINESE:
+        case MARKET_CANADIAN:
+        case MARKET_KOREAN:
+        case MARKET_OTHER_Z:
+        default: 
+            menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
+            break;
+    }
+    
+
 }
 
 static void deinit (void) {

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -107,6 +107,40 @@ static const char *format_cic_type (cic_type_t cic_type) {
     }
 }
 
+static boot_tv_type_t determine_tv_boot_type (destination_type_t rom_destination_code) {
+        // check the market type from the ROM destination_code and return best guess!
+        switch (rom_destination_code) {
+            case MARKET_NORTH_AMERICA:
+            case MARKET_JAPANESE:
+            case MARKET_JAPANESE_MULTI:
+            case MARKET_GATEWAY64_NTSC:
+                return BOOT_TV_TYPE_NTSC;
+            case MARKET_BRAZILIAN:
+                return BOOT_TV_TYPE_MPAL;
+            case MARKET_GERMAN:
+            case MARKET_FRENCH:
+            case MARKET_DUTCH:
+            case MARKET_ITALIAN:
+            case MARKET_SPANISH:
+            case MARKET_AUSTRALIAN:
+            case MARKET_SCANDINAVIAN:  
+            case MARKET_GATEWAY64_PAL:
+            case MARKET_EUROPEAN_BASIC:
+            // FIXME: There might be some interesting errors with OTHER_X and OTHER_Y (e.g. TGR Asia).
+            case MARKET_OTHER_X:
+            case MARKET_OTHER_Y:
+                return BOOT_TV_TYPE_PAL;
+            // FIXME: We cannot be sure on these markets, so just return the default!
+            case MARKET_CHINESE:
+            case MARKET_CANADIAN:
+            case MARKET_KOREAN:
+            case MARKET_OTHER_Z:
+            default: 
+                return BOOT_TV_TYPE_PASSTHROUGH;
+        }
+
+}
+
 
 static void process (menu_t *menu) {
     if (menu->actions.enter) {
@@ -209,41 +243,7 @@ static void load (menu_t *menu) {
     menu->boot_params->detect_cic_seed = true;
     
     if (menu->settings.autodetect_rom_region) {
-        // check the market type (menu->load.rom_info.destination_code) and set best guess?!
-        switch (menu->load.rom_info.destination_code) {
-            case MARKET_NORTH_AMERICA:
-            case MARKET_JAPANESE:
-            case MARKET_JAPANESE_MULTI:
-            case MARKET_GATEWAY64_NTSC:
-                menu->boot_params->tv_type = BOOT_TV_TYPE_NTSC;
-                break;
-            case MARKET_BRAZILIAN:
-                menu->boot_params->tv_type = BOOT_TV_TYPE_MPAL;
-                break;
-            case MARKET_GERMAN:
-            case MARKET_FRENCH:
-            case MARKET_DUTCH:
-            case MARKET_ITALIAN:
-            case MARKET_SPANISH:
-            case MARKET_AUSTRALIAN:
-            case MARKET_SCANDINAVIAN:  
-            case MARKET_GATEWAY64_PAL:
-            case MARKET_EUROPEAN_BASIC:
-            // FIXME: There might be some interesting errors with OTHER_X and OTHER_Y (e.g. TGR Asia).
-            case MARKET_OTHER_X:
-            case MARKET_OTHER_Y:
-                menu->boot_params->tv_type = BOOT_TV_TYPE_PAL;
-                break;
-            // FIXME: We cannot be sure on these markets, so just return the default!
-            case MARKET_CHINESE:
-            case MARKET_CANADIAN:
-            case MARKET_KOREAN:
-            case MARKET_OTHER_Z:
-            default: 
-                menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;
-                break;
-        }
-
+        menu->boot_params->tv_type = determine_tv_boot_type(menu->load.rom_info.destination_code);
     }
     else {
         menu->boot_params->tv_type = BOOT_TV_TYPE_PASSTHROUGH;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add ability to force tv region based on detected ROM based on the ROM's destination code.
Adds a setting so that this can be turned off (on by default).

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->
#66 

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
