### PR TITLE
Hide macOS system files in the root of the SD card

### DIFF
--- a/src/menu/views/browser.c
+++ b/src/menu/views/browser.c
@@ -24,7 +24,14 @@ static const char *hidden_paths[] = {
     "/ED64",
     "/ED64P",
     "/sc64menu.n64",
+    // Windows garbage
     "/System Volume Information",
+    // macOS garbage
+    "/.fseventsd",
+    "/.Spotlight-V100",
+    "/.Trashes",
+    "/.VolumeIcon.icns",
+    "/.metadata_never_index",
     NULL,
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make the root of the SD card a little cleaner by hiding the crap that macOS puts there.

## Motivation and Context
Whenever an SD card touches macOS, a handful of hidden files get created that cannot be touched. N64FlashcartMenu has no need for these files, so they should be hidden.
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
Built and run on SummerCart64 with an NTSC N64
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: meeq <me@christopherbonhage.com>
