### PR TITLE
Improve rumble default state

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -67,6 +67,13 @@ static void menu_init (boot_params_t *boot_params) {
 
     sound_init_default();
 
+    // Ensure that any joypad rumble pak is in a good state when loading the menu.
+    // this can be especially important if a previous ROM has crashed or the console
+    // was reset and left it in an active state.
+    JOYPAD_PORT_FOREACH (port) {
+        joypad_set_rumble_active(port, false);
+    }
+
     menu = calloc(1, sizeof(menu_t));
     assert(menu != NULL);
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -67,9 +67,6 @@ static void menu_init (boot_params_t *boot_params) {
 
     sound_init_default();
 
-    // Ensure that any joypad rumble pak is in a good state when loading the menu.
-    // this can be especially important if a previous ROM has crashed or the console
-    // was reset and left it in an active state.
     JOYPAD_PORT_FOREACH (port) {
         joypad_set_rumble_active(port, false);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When loading the menu, ensure that any connected rumble paks are not rumbling.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->
It is possible that they would continue to rumble after a ROM has crashed or the console was reset from a game where the accessory was currently rumbling.

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
