### PR TITLE
[develop] Add rom override config folder setting

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -93,6 +93,8 @@ static void menu_init (boot_params_t *boot_params) {
 
     sound_use_sfx(menu->settings.sound_enabled);
 
+    rom_info_use_config_folder(menu->settings.use_gamepak_custom_config_folder);
+
     menu->browser.directory = path_init(menu->storage_prefix, menu->settings.default_directory);
     if (!directory_exists(path_get(menu->browser.directory))) {
         path_free(menu->browser.directory);

--- a/src/menu/rom_info.c
+++ b/src/menu/rom_info.c
@@ -4,8 +4,6 @@
 
 #include <mini.c/src/mini.h>
 
-#include "views/views.h"
-
 #include "boot/cic.h"
 #include "rom_info.h"
 #include "utils/fs.h"
@@ -612,6 +610,19 @@ static const match_t database[] = {
 // clang-format on
 
 
+static bool gamepak_config_folder_enabled = false;
+
+
+void rom_info_use_config_folder(bool state) {
+    if (state) {
+        gamepak_config_folder_enabled = true;
+    }
+    else {
+        gamepak_config_folder_enabled = false;
+    }
+}
+
+
 static void fix_rom_header_endianness (rom_header_t *rom_header, rom_info_t *rom_info) {
     uint8_t *raw = (uint8_t *) (rom_header);
 
@@ -809,9 +820,9 @@ static bool create_gamepak_config_subdirectory (path_t *path) {
     return error;
 }
 
-static void load_overrides (path_t *path, rom_info_t *rom_info) {
+static void load_rom_config_overrides (path_t *path, rom_info_t *rom_info) {
 
-    if ( menu->settings.use_gamepak_config_folder) {
+    if ( gamepak_config_folder_enabled ) {
         path_push_subdir(path, GAMEPAK_CONFIG_SUBDIRECTORY);
     }
 
@@ -847,9 +858,9 @@ static void load_overrides (path_t *path, rom_info_t *rom_info) {
     path_free(overrides_path);
 }
 
-static rom_err_t save_override (path_t *path, const char *id, int value, int default_value) {
+static rom_err_t save_rom_config_overrides (path_t *path, const char *id, int value, int default_value) {
 
-    if ( menu->settings.use_gamepak_config_folder) {
+    if ( gamepak_config_folder_enabled ) {
         // if the sub dir does not exist, create it
         // TODO: would it be quicker to check it exists first?
         create_gamepak_config_subdirectory(path);
@@ -943,7 +954,7 @@ rom_err_t rom_info_override_cic_type (path_t *path, rom_info_t *rom_info, rom_ci
     rom_info->override.cic = (cic_type != ROM_CIC_TYPE_AUTOMATIC);
     rom_info->override.cic_type = cic_type;
 
-    return save_override(path, "cic_type", rom_info->override.cic_type, ROM_CIC_TYPE_AUTOMATIC);
+    return save_rom_config_overrides(path, "cic_type", rom_info->override.cic_type, ROM_CIC_TYPE_AUTOMATIC);
 }
 
 rom_save_type_t rom_info_get_save_type (rom_info_t *rom_info) {
@@ -958,7 +969,7 @@ rom_err_t rom_info_override_save_type (path_t *path, rom_info_t *rom_info, rom_s
     rom_info->override.save = (save_type != SAVE_TYPE_AUTOMATIC);
     rom_info->override.save_type = save_type;
 
-    return save_override(path, "save_type", rom_info->override.save_type, SAVE_TYPE_AUTOMATIC);
+    return save_rom_config_overrides(path, "save_type", rom_info->override.save_type, SAVE_TYPE_AUTOMATIC);
 }
 
 rom_tv_type_t rom_info_get_tv_type (rom_info_t *rom_info) {
@@ -973,7 +984,7 @@ rom_err_t rom_info_override_tv_type (path_t *path, rom_info_t *rom_info, rom_tv_
     rom_info->override.tv = (tv_type != ROM_TV_TYPE_AUTOMATIC);
     rom_info->override.tv_type = tv_type;
 
-    return save_override(path, "tv_type", rom_info->override.tv_type, ROM_TV_TYPE_AUTOMATIC);
+    return save_rom_config_overrides(path, "tv_type", rom_info->override.tv_type, ROM_TV_TYPE_AUTOMATIC);
 }
 
 rom_err_t rom_info_load (path_t *path, rom_info_t *rom_info) {
@@ -998,7 +1009,7 @@ rom_err_t rom_info_load (path_t *path, rom_info_t *rom_info) {
 
     extract_rom_info(&match, &rom_header, rom_info);
 
-    load_overrides(path, rom_info);
+    load_rom_config_overrides(path, rom_info);
 
     return ROM_OK;
 }

--- a/src/menu/rom_info.h
+++ b/src/menu/rom_info.h
@@ -237,5 +237,7 @@ rom_err_t rom_info_override_tv_type (path_t *path, rom_info_t *rom_info, rom_tv_
 
 rom_err_t rom_info_load (path_t *path, rom_info_t *rom_info);
 
+void rom_info_use_config_folder(bool state);
+
 
 #endif

--- a/src/menu/settings.c
+++ b/src/menu/settings.c
@@ -13,6 +13,7 @@ static settings_t init = {
     .show_protected_entries = false,
     .default_directory = "/",
     .use_saves_folder = true,
+    .use_gamepak_custom_config_folder = false,
     .sound_enabled = true,
 
     /* Beta feature flags (should always init to off) */
@@ -39,6 +40,7 @@ void settings_load (settings_t *settings) {
     settings->show_protected_entries = mini_get_bool(ini, "menu", "show_protected_entries", init.show_protected_entries);
     settings->default_directory = strdup(mini_get_string(ini, "menu", "default_directory", init.default_directory));
     settings->use_saves_folder = mini_get_bool(ini, "menu", "use_saves_folder", init.use_saves_folder);
+    settings->use_gamepak_custom_config_folder = mini_get_bool(ini, "menu", "use_gamepak_custom_config_folder", init.use_gamepak_custom_config_folder);
     settings->sound_enabled = mini_get_bool(ini, "menu", "sound_enabled", init.sound_enabled);
 
     /* Beta feature flags, they might not be in the file */
@@ -55,6 +57,7 @@ void settings_save (settings_t *settings) {
     mini_set_bool(ini, "menu", "show_protected_entries", settings->show_protected_entries);
     mini_set_string(ini, "menu", "default_directory", settings->default_directory);
     mini_set_bool(ini, "menu", "use_saves_folder", settings->use_saves_folder);
+    mini_set_bool(ini, "menu", "use_gamepak_custom_config_folder", settings->use_gamepak_custom_config_folder);
     mini_set_bool(ini, "menu", "sound_enabled", settings->sound_enabled);
 
     /* Beta feature flags, they should not save until production ready! */

--- a/src/menu/settings.h
+++ b/src/menu/settings.h
@@ -22,6 +22,9 @@ typedef struct {
     /** @brief Put saves into separate directory */
     bool use_saves_folder;
 
+    /** @brief Put custom GamePak configs into separate directory */
+    bool use_gamepak_custom_config_folder;
+
     /** @brief Enable Background music */
     bool bgm_enabled;
 

--- a/src/menu/views/settings_editor.c
+++ b/src/menu/views/settings_editor.c
@@ -30,6 +30,7 @@ static void set_use_saves_folder_type (menu_t *menu, void *arg) {
 
 static void set_use_gamepak_custom_config_folder_type (menu_t *menu, void *arg) {
     menu->settings.use_gamepak_custom_config_folder = (bool) (arg);
+    rom_info_use_config_folder(menu->settings.use_gamepak_custom_config_folder);
     settings_save(&menu->settings);
 }
 

--- a/src/menu/views/settings_editor.c
+++ b/src/menu/views/settings_editor.c
@@ -28,6 +28,11 @@ static void set_use_saves_folder_type (menu_t *menu, void *arg) {
     settings_save(&menu->settings);
 }
 
+static void set_use_gamepak_custom_config_folder_type (menu_t *menu, void *arg) {
+    menu->settings.use_gamepak_custom_config_folder = (bool) (arg);
+    settings_save(&menu->settings);
+}
+
 static void set_sound_enabled_type (menu_t *menu, void *arg) {
     menu->settings.sound_enabled = (bool) (arg);
     sound_use_sfx(menu->settings.sound_enabled);
@@ -76,6 +81,12 @@ static component_context_menu_t set_use_saves_folder_type_context_menu = { .list
     COMPONENT_CONTEXT_MENU_LIST_END,
 }};
 
+static component_context_menu_t set_use_gamepak_custom_config_folder_type_context_menu = { .list = {
+    {.text = "On", .action = set_use_gamepak_custom_config_folder_type, .arg = (void *) (true) },
+    {.text = "Off", .action = set_use_gamepak_custom_config_folder_type, .arg = (void *) (false) },
+    COMPONENT_CONTEXT_MENU_LIST_END,
+}};
+
 #ifdef BETA_SETTINGS
 static component_context_menu_t set_bgm_enabled_type_context_menu = { .list = {
     {.text = "On", .action = set_bgm_enabled_type, .arg = (void *) (true) },
@@ -95,6 +106,7 @@ static component_context_menu_t options_context_menu = { .list = {
     { .text = "Show Hidden Files", .submenu = &set_protected_entries_type_context_menu },
     { .text = "Sound Effects", .submenu = &set_sound_enabled_type_context_menu },
     { .text = "Use Saves Folder", .submenu = &set_use_saves_folder_type_context_menu },
+    { .text = "Use Game Config Folder", .submenu = &set_use_gamepak_custom_config_folder_type_context_menu },
 #ifdef BETA_SETTINGS
     { .text = "Background Music", .submenu = &set_bgm_enabled_type_context_menu },
     { .text = "Rumble Feedback", .submenu = &set_rumble_enabled_type_context_menu },
@@ -140,6 +152,7 @@ static void draw (menu_t *menu, surface_t *d) {
         "*    PAL60 Mode        : %s\n"
         "     Show Hidden Files : %s\n"
         "     Use Saves folder  : %s\n"
+        "     Use config folder : %s\n"
         "     Sound Effects     : %s\n"
 #ifdef BETA_SETTINGS
         "     Background Music  : %s\n"
@@ -151,6 +164,7 @@ static void draw (menu_t *menu, surface_t *d) {
         format_switch(menu->settings.pal60_enabled),
         format_switch(menu->settings.show_protected_entries),
         format_switch(menu->settings.use_saves_folder),
+        format_switch(menu->settings.use_gamepak_custom_config_folder),
         format_switch(menu->settings.sound_enabled)
 #ifdef BETA_SETTINGS
         ,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the ability to store custom ROM settings in a seperate folder, rather than in the path of the ROM.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
