### PR TITLE
[develop] Disk info view - load with rom - button context

### DIFF
--- a/src/menu/menu_state.h
+++ b/src/menu/menu_state.h
@@ -103,6 +103,7 @@ typedef struct {
         rom_info_t rom_info;
         path_t *disk_path;
         disk_info_t disk_info;
+        bool combined_disk_rom;
     } load;
 
     struct {

--- a/src/menu/views/load_disk.c
+++ b/src/menu/views/load_disk.c
@@ -4,8 +4,6 @@
 #include "../sound.h"
 #include "views.h"
 
-
-static bool load_disk_with_rom;
 static component_boxart_t *boxart;
 
 
@@ -31,10 +29,10 @@ static char *format_disk_region (disk_region_t region) {
 static void process (menu_t *menu) {
     if (menu->actions.enter) {
         menu->boot_pending.disk_file = true;
-        load_disk_with_rom = false;
+        menu->load.combined_disk_rom = false;
     } else if (menu->actions.options && menu->load.rom_path) {
         menu->boot_pending.disk_file = true;
-        load_disk_with_rom = true;
+        menu->load.combined_disk_rom = true;
         sound_play_effect(SFX_SETTING);
     } else if (menu->actions.back) {
         sound_play_effect(SFX_EXIT);
@@ -118,7 +116,7 @@ static void draw_progress (float progress) {
 static void load (menu_t *menu) {
     cart_load_err_t err;
 
-    if (menu->load.rom_path && load_disk_with_rom) {
+    if (menu->load.rom_path && menu->load.combined_disk_rom) {
         err = cart_load_n64_rom_and_save(menu, draw_progress);
         if (err != CART_LOAD_OK) {
             menu_show_error(menu, cart_load_convert_error_message(err));
@@ -134,7 +132,7 @@ static void load (menu_t *menu) {
 
     menu->next_mode = MENU_MODE_BOOT;
 
-    if (load_disk_with_rom) {
+    if (menu->load.combined_disk_rom) {
         menu->boot_params->device_type = BOOT_DEVICE_TYPE_ROM;
         menu->boot_params->detect_cic_seed = rom_info_get_cic_seed(&menu->load.rom_info, &menu->boot_params->cic_seed);
         switch (rom_info_get_tv_type(&menu->load.rom_info)) {

--- a/src/menu/views/load_disk.c
+++ b/src/menu/views/load_disk.c
@@ -30,7 +30,7 @@ static void process (menu_t *menu) {
     if (menu->actions.enter) {
         menu->boot_pending.disk_file = true;
         menu->load.combined_disk_rom = false;
-    } else if (menu->actions.options && menu->load.rom_path) {
+    } else if (menu->actions.lz_context && menu->load.rom_path) {
         menu->boot_pending.disk_file = true;
         menu->load.combined_disk_rom = true;
         sound_play_effect(SFX_SETTING);
@@ -87,7 +87,7 @@ static void draw (menu_t *menu, surface_t *d) {
         if (menu->load.rom_path) {
             ui_components_actions_bar_text_draw(
                 ALIGN_RIGHT, VALIGN_TOP,
-                "R: Load with ROM"
+                "L|Z: Load with ROM\n"
             );
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the button context from `R` to `L|Z` and moves the `move load_disk_with_rom` to `menu_state` so that it can be used for things like autoload.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->
Aligns the button context with the ROM info menu.
Makes it easier to set and re-use expansion ROM's.

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [x] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
