### PR TITLE
Fix for crashing when deleting a favorite

### DIFF
--- a/src/menu/bookkeeping.c
+++ b/src/menu/bookkeeping.c
@@ -111,7 +111,7 @@ static void bookkeeping_clear_item(bookkeeping_item_t *item, bool leave_null) {
 static void bookkeeping_copy_item(bookkeeping_item_t *source, bookkeeping_item_t *destination) {
     bookkeeping_clear_item(destination, true);
 
-    destination->primary_path = path_clone(source->primary_path);    
+    destination->primary_path =  source->primary_path != NULL ? path_clone(source->primary_path) : path_create("");   
     destination->secondary_path = source->secondary_path != NULL ? path_clone(source->secondary_path) : path_create("");
     destination->bookkeeping_type = source->bookkeeping_type;
 }
@@ -134,7 +134,7 @@ static void bookkeeping_move_items_up(bookkeeping_item_t *list, int start, int e
     int current = start;
 
     do {
-        if(current > end) {
+        if(current >= end) {
             break;
         }        
 


### PR DESCRIPTION
Fix for crashing when deleting a favorite

## Description
Fixed a bounds check that allowed the copy loop to go out of bounds.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
