### PR TITLE
settings: Add setting for forcing progressive scan in VI

### DIFF
--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -33,7 +33,6 @@
 #define MENU_CACHE_DIRECTORY        "cache"
 #define BACKGROUND_CACHE_FILE       "background.data"
 
-#define INTERLACED                  (true)
 #define FPS_LIMIT                   (30.0f)
 
 static menu_t *menu;
@@ -45,6 +44,7 @@ static tv_type_t tv_type;
 extern int __boot_tvtype;
 /* -- */
 
+static bool interlaced = true;
 
 /**
  * @brief Initialize the menu system.
@@ -102,14 +102,17 @@ static void menu_init (boot_params_t *boot_params) {
         }
     }
 
+    // Force interlacing off in VI settings for TVs and other devices that struggle with interlaced video input.
+    interlaced = !menu->settings.force_progressive_scan;
+
     resolution_t resolution = {
         .width = 640,
         .height = 480,
-        .interlaced = INTERLACED ? INTERLACE_HALF : INTERLACE_OFF,
+        .interlaced = interlaced ? INTERLACE_HALF : INTERLACE_OFF,
         .pal60 = menu->settings.pal60_enabled, // this may be overridden by the PAL60 compatibility mode.
     };
 
-    display_init(resolution, DEPTH_16_BPP, 2, GAMMA_NONE, INTERLACED ? FILTERS_DISABLED : FILTERS_RESAMPLE);
+    display_init(resolution, DEPTH_16_BPP, 2, GAMMA_NONE, interlaced ? FILTERS_DISABLED : FILTERS_RESAMPLE);
     display_set_fps_limit(FPS_LIMIT);
 
     path_push(path, MENU_CUSTOM_FONT_FILE);

--- a/src/menu/settings.c
+++ b/src/menu/settings.c
@@ -13,6 +13,7 @@ static settings_t init = {
     .first_run = true,
     .pal60_enabled = false,
     .pal60_compatibility_mode = true,
+    .force_progressive_scan = false,
     .show_protected_entries = false,
     .default_directory = "/",
     .use_saves_folder = true,
@@ -47,6 +48,7 @@ void settings_load (settings_t *settings) {
     settings->first_run = mini_get_bool(ini, "menu", "first_run", init.first_run);
     settings->pal60_enabled = mini_get_bool(ini, "menu", "pal60", init.pal60_enabled); // TODO: consider changing file setting name
     settings->pal60_compatibility_mode = mini_get_bool(ini, "menu", "pal60_compatibility_mode", init.pal60_compatibility_mode);
+    settings->force_progressive_scan = mini_get_bool(ini, "menu", "force_progressive_scan", init.force_progressive_scan);
     settings->show_protected_entries = mini_get_bool(ini, "menu", "show_protected_entries", init.show_protected_entries);
     settings->default_directory = strdup(mini_get_string(ini, "menu", "default_directory", init.default_directory));
     settings->use_saves_folder = mini_get_bool(ini, "menu", "use_saves_folder", init.use_saves_folder);
@@ -72,6 +74,7 @@ void settings_save (settings_t *settings) {
     mini_set_bool(ini, "menu", "first_run", settings->first_run);
     mini_set_bool(ini, "menu", "pal60", settings->pal60_enabled);
     mini_set_bool(ini, "menu", "pal60_compatibility_mode", settings->pal60_compatibility_mode);
+    mini_set_bool(ini, "menu", "force_progressive_scan", settings->force_progressive_scan);
     mini_set_bool(ini, "menu", "show_protected_entries", settings->show_protected_entries);
     mini_set_string(ini, "menu", "default_directory", settings->default_directory);
     mini_set_bool(ini, "menu", "use_saves_folder", settings->use_saves_folder);

--- a/src/menu/settings.h
+++ b/src/menu/settings.h
@@ -22,6 +22,9 @@ typedef struct {
     /** @brief Use 60 Hz refresh rate on a PAL console with certain mods that do not properly the video output */
     bool pal60_compatibility_mode;
 
+    /** @brief Direct the VI to force progressive scan output at 240p. Meant for TVs and other devices which struggle to display interlaced video. */
+    bool force_progressive_scan;
+
     /** @brief Show files/directories that are filtered in the browser */
     bool show_protected_entries;
 


### PR DESCRIPTION
This PR adds a setting to the config that allows users with TVs, scalers, and other devices that struggle with interlaced video input to force progressive scan to the menu.

## Description
This PR implements the aforementioned new setting my changing libdragon's display module setting from `INTERLACE_HALF` to `INTERLACE_OFF` if the newly added `force_progressive_scan` setting bool is set. This tells the display module to not set the serrate bit in the VI configuration registers and in effect forces "artificial" progressive scan at 240p by dropping one field, without having to modify the menu's rendering resolution of 640x480. 

## Motivation and Context
Motivated by currently open issues #59 and #82 as well as Discord comments from some menu users:
- https://discord.com/channels/205520502922543113/1262536014623146125/1349024387721986061
- https://discord.com/channels/205520502922543113/1262536014623146125/1349025967351271445
- https://discord.com/channels/205520502922543113/1262536014623146125/1349030951585579058

## How Has This Been Tested?
Tested in ares. Testing on real devices by affected users would be appreciated.

## Types of changes
- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: thekovic 72971433+thekovic@users.noreply.github.com
