### PR TITLE
boot: reset value of FCR31 to the boot value (0)

### DIFF
--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -58,6 +58,7 @@ void boot (boot_params_t *params) {
     }
 
     C0_WRITE_STATUS(C0_STATUS_CU1 | C0_STATUS_CU0 | C0_STATUS_FR);
+    C1_WRITE_FCR31(0);
 
     while (!(cpu_io_read(&SP->SR) & SP_SR_HALT));
 


### PR DESCRIPTION
This improves emulation of cold boot, as otherwise the FPU might start in an unexpected state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved initialization procedures during system boot for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->