### PR TITLE
Support loading Modem ROM into SC64

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+ko_fi: polprzewodnikowy
+github: networkfusion

--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -58,6 +58,7 @@ void boot (boot_params_t *params) {
     }
 
     C0_WRITE_STATUS(C0_STATUS_CU1 | C0_STATUS_CU0 | C0_STATUS_FR);
+    C1_WRITE_FCR31(0);
 
     while (!(cpu_io_read(&SP->SR) & SP_SR_HALT));
 

--- a/src/flashcart/64drive/64drive.c
+++ b/src/flashcart/64drive/64drive.c
@@ -367,6 +367,7 @@ static flashcart_t flashcart_d64 = {
     .has_feature = d64_has_feature,
     .get_firmware_version = d64_get_firmware_version,
     .load_rom = d64_load_rom,
+    .load_second_rom = NULL,
     .load_file = d64_load_file,
     .load_save = d64_load_save,
     .load_64dd_ipl = NULL,

--- a/src/flashcart/ed64/ed64_vseries.c
+++ b/src/flashcart/ed64/ed64_vseries.c
@@ -155,6 +155,7 @@ static flashcart_t flashcart_ed64_vseries = {
     .has_feature = ed64_vseries_has_feature,
     .get_firmware_version = ed64_vseries_get_firmware_version,
     .load_rom = ed64_vseries_load_rom,
+    .load_second_rom = NULL,
     .load_file = ed64_vseries_load_file,
     .load_save = ed64_vseries_load_save,
     .load_64dd_ipl = NULL,

--- a/src/flashcart/ed64/ed64_xseries.c
+++ b/src/flashcart/ed64/ed64_xseries.c
@@ -159,6 +159,7 @@ static flashcart_t flashcart_ed64_xseries = {
     .has_feature = ed64_xseries_has_feature,
     .get_firmware_version = ed64_xseries_get_firmware_version,
     .load_rom = ed64_xseries_load_rom,
+    .load_second_rom = NULL,
     .load_file = ed64_xseries_load_file,
     .load_save = ed64_xseries_load_save,
     .load_64dd_ipl = NULL,

--- a/src/flashcart/flashcart.c
+++ b/src/flashcart/flashcart.c
@@ -101,6 +101,7 @@ static flashcart_t *flashcart = &((flashcart_t) {
     .deinit = NULL,
     .has_feature = dummy_has_feature,
     .load_rom = dummy_load_rom,
+    .load_second_rom = dummy_load_rom,
     .load_file = dummy_load_file,
     .load_save = dummy_load_save,
     .load_64dd_ipl = NULL,
@@ -246,6 +247,28 @@ flashcart_err_t flashcart_load_rom (char *rom_path, bool byte_swap, flashcart_pr
 
     cart_card_byteswap = byte_swap;
     err = flashcart->load_rom(rom_path, progress);
+    cart_card_byteswap = false;
+
+    return err;
+}
+
+/**
+ * @brief Load a secondary ROM into the flashcart.
+ *
+ * @param rom_path Path to the ROM file.
+ * @param byte_swap Flag indicating whether to byte swap the ROM.
+ * @param progress Progress callback function.
+ * @return flashcart_err_t Error code.
+ */
+flashcart_err_t flashcart_load_second_rom (char *rom_path, bool byte_swap, flashcart_progress_callback_t *progress) {
+    flashcart_err_t err;
+
+    if (rom_path == NULL) {
+        return FLASHCART_ERR_ARGS;
+    }
+
+    cart_card_byteswap = byte_swap;
+    err = flashcart->load_second_rom(rom_path, progress);
     cart_card_byteswap = false;
 
     return err;

--- a/src/flashcart/flashcart.h
+++ b/src/flashcart/flashcart.h
@@ -86,6 +86,8 @@ typedef struct {
     flashcart_firmware_version_t (*get_firmware_version) (void);
     /** @brief The flashcart ROM load function */
     flashcart_err_t (*load_rom) (char *rom_path, flashcart_progress_callback_t *progress);
+    /** @brief The flashcart secondary ROM load function */
+    flashcart_err_t (*load_second_rom)(char *rom_path, flashcart_progress_callback_t *progress);
     /** @brief The flashcart file load function */
     flashcart_err_t (*load_file) (char *file_path, uint32_t rom_offset, uint32_t file_offset);
     /** @brief The flashcart save file load function */
@@ -149,6 +151,16 @@ flashcart_firmware_version_t flashcart_get_firmware_version (void);
  * @return flashcart_err_t Error code.
  */
 flashcart_err_t flashcart_load_rom (char *rom_path, bool byte_swap, flashcart_progress_callback_t *progress);
+
+/**
+ * @brief Load a secondary ROM onto the flashcart.
+ *
+ * @param rom_path The path to the ROM file.
+ * @param byte_swap Whether to byte swap the ROM.
+ * @param progress Callback function for progress updates.
+ * @return flashcart_err_t Error code.
+ */
+flashcart_err_t flashcart_load_second_rom (char *rom_path, bool byte_swap, flashcart_progress_callback_t *progress);
 
 /**
  * @brief Load a file onto the flashcart.

--- a/src/flashcart/sc64/sc64.c
+++ b/src/flashcart/sc64/sc64.c
@@ -498,6 +498,7 @@ static flashcart_err_t sc64_load_save (char *save_path) {
         case SAVE_TYPE_SRAM_256KBIT:
         case SAVE_TYPE_FLASHRAM_1MBIT:
         case SAVE_TYPE_SRAM_BANKED:
+        case SAVE_TYPE_SRAM_1MBIT:
             address = (void *) (SRAM_FLASHRAM_ADDRESS);
             break;
         case SAVE_TYPE_NONE:

--- a/src/menu/cart_load.c
+++ b/src/menu/cart_load.c
@@ -20,6 +20,9 @@
 #ifndef EMU_LOCATION
 #define EMU_LOCATION            "/menu/emulators"
 #endif
+#ifndef MODEM_LOCATION
+#define MODEM_LOCATION          "/menu/modem"
+#endif
 
 /**
  * @brief Check if the 64DD is connected.
@@ -92,6 +95,27 @@ char *cart_load_convert_error_message (cart_load_err_t err) {
     }
 }
 
+cart_load_err_t cart_load_modem (menu_t *menu, flashcart_progress_callback_t progress) {
+    path_t *path = path_init(menu->storage_prefix, MODEM_LOCATION);
+    path_push(path, "CMDJ0.n64");
+    if (!file_exists(path_get(path))) {
+        path_free(path);
+        return CART_LOAD_ERR_MODEM_NOT_FOUND;
+    }
+
+    bool byte_swap = (menu->load.rom_info.endianness == ENDIANNESS_BYTE_SWAP);
+    menu->flashcart_err = flashcart_load_second_rom(path_get(path), byte_swap, progress);
+    
+    if (menu->flashcart_err != FLASHCART_OK) {
+        path_free(path);
+        return CART_LOAD_ERR_ROM_LOAD_FAIL;
+    }
+
+    path_free(path);
+
+    return CART_LOAD_OK;
+}
+
 /**
  * @brief Load an N64 ROM and its save file.
  * 
@@ -100,6 +124,7 @@ char *cart_load_convert_error_message (cart_load_err_t err) {
  * @return cart_load_err_t Error code.
  */
 cart_load_err_t cart_load_n64_rom_and_save (menu_t *menu, flashcart_progress_callback_t progress) {
+    cart_load_modem(menu, NULL);
     path_t *path = path_clone(menu->load.rom_path);
 
     bool byte_swap = (menu->load.rom_info.endianness == ENDIANNESS_BYTE_SWAP);
@@ -150,6 +175,8 @@ cart_load_err_t cart_load_n64_rom_and_save (menu_t *menu, flashcart_progress_cal
  * @return cart_load_err_t Error code.
  */
 cart_load_err_t cart_load_64dd_ipl_and_disk (menu_t *menu, flashcart_progress_callback_t progress) {
+    //cart_load_modem(menu, NULL);
+
     if (!flashcart_has_feature(FLASHCART_FEATURE_64DD)) {
         return CART_LOAD_ERR_FUNCTION_NOT_SUPPORTED;
     }

--- a/src/menu/cart_load.h
+++ b/src/menu/cart_load.h
@@ -42,6 +42,8 @@ typedef enum {
     CART_LOAD_ERR_EXP_PAK_NOT_FOUND,
     /** @brief An unexpected response. */
     CART_LOAD_ERR_FUNCTION_NOT_SUPPORTED,
+    /** @brief Failed to load the 64DD Modem file. */
+    CART_LOAD_ERR_MODEM_NOT_FOUND,
 } cart_load_err_t;
 
 /** @brief Cart load type enumeration */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
These changes allow for loading a second rom (i.e. the modem rom) into the upper rom space at 0x18000000 (at 128MB).
To enable this feature, the modem rom must be present in the SD Card in `/menu/modem/CMDJ0.n64`, and the game rom being loaded must not exceed 64MB. If either of these fail the modem loading with gracefully fail as well and the game will load as normal.

A couple of bugs need to be fixed & tests run before the PR is merged:
- Loading the Modem would freeze the progress bar on 64DD mode.
- Loading the Modem on standalone cartridges appeared to work(?).
- There are no safety checks for the physical Modem before attempting to emulate it (this may also need to be fixed with the SC64 FW). This is of similar importance to the already-present physical 64DD checks.
- The Modem loading should only occur when the game ROM is <= 64MB, instead of loading it unconditionally and overwriting it when a game ROM is > 64MB, which is the current implementation.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
This allows for loading in a virtual modem into the SummerCart64 without relying on the official device locked behind eBay prices. Custom roms are also allowed, specifically for future open-source modem libraries that make use of the SC64's USB port.
The goal would be to allow the large userbase of SC64 users (and eventually flashcart users as a whole), to connect retail games online without extra hardware.
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After building the menu a few times I was able to successfully get past the error on the title screen of the Randnet Disk that normally displays the "modem not found" error when the modem is not physically connected.
This was tested on a real N64 with SC64 installed, loading Randnet Disk, with the modem rom in the SD Card in `/menu/modem/CMDJ0.n64`, no physical modem cart installed, and using [this SC64 firmware](https://github.com/Polprzewodnikowy/SummerCart64/pull/116).


## Screenshots
<!-- (if appropriate): -->
<img width="329" height="430" alt="image" src="https://github.com/user-attachments/assets/7e3b6b8f-19c9-4664-8044-990c06dd795c" />
<img width="317" height="406" alt="image" src="https://github.com/user-attachments/assets/d531444f-6da9-43e7-adb6-318809e845b0" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [x] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: newgbaxl newgbaxl@gmail.com
