### PR TITLE
menu: Send the player # to each controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ SRCS = \
 	menu/disk_info.c \
 	menu/fonts.c \
 	menu/hdmi.c \
+	menu/joypad.c \
 	menu/menu.c \
 	menu/mp3_player.c \
 	menu/path.c \

--- a/src/menu/joypad.c
+++ b/src/menu/joypad.c
@@ -1,0 +1,58 @@
+/**
+ * @file joypad.c
+ * @brief Joypad system implementation
+ * @ingroup joypad
+ */
+
+#include <libdragon.h>
+
+#include "joypad.h"
+
+/**
+ * @brief "Player ID" Joybus command structure.
+ *
+ * This is a custom command not supported by official controllers.
+ * 
+ * @see #JOYBUS_COMMAND_ID_PLAYER_IDENTIFY
+ */
+typedef struct __attribute__((packed)) joybus_cmd_player_id_s
+{
+    /** @brief "Player ID" command send data */
+    struct __attribute__((__packed__))
+    {
+        /** @brief Joybus command ID (#JOYBUS_COMMAND_ID_PLAYER_IDENTIFY) */
+        uint8_t command;
+        /** @brief Bitmask with a single bit set indicating the port number */
+        uint8_t bitmask;
+    } send;
+    /** @brief Controller responds with the old bitmask */
+    uint8_t recv;
+} joybus_cmd_player_id_t;
+
+void joypad_send_player_id(void) {
+    uint8_t input[JOYBUS_BLOCK_SIZE] = {0};
+    joybus_cmd_player_id_t cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_PLAYER_IDENTIFY,
+    }};
+    const size_t recv_offset = offsetof(typeof(cmd), recv);
+    size_t i = 0;
+
+    // Populate the Joybus commands on each port
+    JOYPAD_PORT_FOREACH (port)
+    {
+        cmd.send.bitmask = 1 << port;
+        // Set the command metadata
+        input[i++] = sizeof(cmd.send);
+        input[i++] = sizeof(cmd.recv);
+        // Micro-optimization: Minimize copy length
+        memcpy(&input[i], &cmd, recv_offset);
+        i += sizeof(cmd);
+    }
+
+    // Close out the Joybus operation block
+    input[i] = 0xFE;
+    input[JOYBUS_BLOCK_SIZE - 1] = 0x01;
+
+    // This is a fire-and-forget command where the response can be ignored
+    joybus_exec_async(input, NULL, NULL);
+}

--- a/src/menu/joypad.h
+++ b/src/menu/joypad.h
@@ -1,0 +1,27 @@
+/**
+ * @file joypad.h
+ * @brief Joypad Subsystem
+ * @ingroup joypad
+ */
+
+#ifndef JOYPAD_H__
+#define JOYPAD_H__
+
+/**
+ * @brief "Player ID" Joybus command identifier.
+ * 
+ * Custom command that is not supported by official controllers.
+ */
+#define JOYBUS_COMMAND_ID_PLAYER_IDENTIFY 0xF0
+
+/**
+ * @brief Sends the player ID to each controller.
+ *
+ * This function sends the player ID to each controller coresponding to the
+ * joybus slot the controller is plugged in to.
+ *
+ * This is a custom command which is not supported by official controllers.
+ */
+void joypad_send_player_id(void);
+
+#endif // JOYPAD_H__

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -15,6 +15,7 @@
 #include "flashcart/flashcart.h"
 #include "fonts.h"
 #include "hdmi.h"
+#include "joypad.h"
 #include "menu_state.h"
 #include "menu.h"
 #include "mp3_player.h"
@@ -77,6 +78,7 @@ static void menu_init (boot_params_t *boot_params) {
     sound_init_sfx();
 
     hdmi_clear_game_id();
+    joypad_send_player_id();
 
     path_t *path = path_init(menu->storage_prefix, MENU_DIRECTORY);
 


### PR DESCRIPTION
## Description
This allows third-party controllers to light up the correct player LED.

## Motivation and Context
This change sends a command when the menu initializes that identifies to the controller which port it's plugged into. We then expect the controller to remember this player ID until the next command overwrites it.

The only flaw with this design is that it will be incorrect if the controller is unplugged an plugged into another port. However solving that especially when a ROM is running would add too much complexity for a small feature like this.

So far no third-party controllers implement it as this is just for my own personal project, but I can see it being generally useful if a command is standardized for this.

## How Has This Been Tested?
I've implemented support for this on my own raspberry pi pico adapter with a wired N64 NSO controller. I've confirmed the correct LED lights up when the menu boots up.

I've also confirmed that when plugging the controller into another port and resetting the console that the LED is updated as expected.

## Screenshots
N/A

## Types of changes
- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.
