### PR TITLE
Boxart image cycling

### DIFF
--- a/docs/19_gamepak_boxart.md
+++ b/docs/19_gamepak_boxart.md
@@ -1,6 +1,6 @@
 [Return to the index](./00_index.md)
 ## Game Art Images
-To use N64 game boxart images, place your PNG files within the `sd:/menu/metadata/` folder.
+To use N64 game art images, place your PNG files within the `sd:/menu/metadata/` folder.
 
 > [!WARNING]
 > ** PRE-RELEASE ONLY**
@@ -11,7 +11,7 @@ Files must be in `PNG` format and use the following dimensions:
 * American/European N64 boxart sprites: 158x112
 * Japanese N64 boxart sprites: 112x158
 * 64DD boxart sprites: 129x112
-* GamePak front and back: 158x112
+* GamePak front and back sprites: 158x112
 
 Images will be loaded by directories using each character (case-sensitive) of the full 4-character Game Code (as identified in the menu ROM information):  
 i.e. for GoldenEye NTSC USA (NGEE), this would be `sd:/menu/boxart/N/G/E/E/boxart_front.png`.  
@@ -32,8 +32,8 @@ e.g. `sd:/menu/metadata/homebrew/{game title}/boxart_front.png`
 - `gamepak_front.png`
 - `gamepak_back.png`
 
-#### Cycling through images
-On the ROM load screen, you can cycle through available images using the **D-pad left** and **D-pad right** buttons, or by selecting **Cycle Next Image** from the context menu. The menu will display any available images from the list above, skipping images that don't exist.
+#### Cycling through game art images
+On the ROM load screen, you can cycle through available images using the **D-pad left** and **D-pad right** buttons. The menu will display any available images from the list above, skipping images that don't exist.
 
 As a starting point, here is a link to a box art pack, that has `boxart_front.png`:  
 - [Third party box art](https://drive.google.com/file/d/1IpCmFqmGgGwKKmlRBxYObfFR9XywaC6n/view?usp=drive_link)

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -13,8 +13,8 @@ static bool show_extra_info_message = false;
 static component_boxart_t *boxart;
 static char *rom_filename = NULL;
 
-static int current_image_index = 0;
-static const file_image_type_t image_cycle[] = {
+static int16_t current_metadata_image_index = 0;
+static const file_image_type_t metadata_image_cycle[] = {
     IMAGE_BOXART_FRONT,
     IMAGE_BOXART_BACK,
     IMAGE_BOXART_LEFT,
@@ -24,14 +24,14 @@ static const file_image_type_t image_cycle[] = {
     IMAGE_GAMEPAK_FRONT,
     IMAGE_GAMEPAK_BACK
 };
-static const int image_cycle_length = sizeof(image_cycle) / sizeof(image_cycle[0]);
-static bool image_available[sizeof(image_cycle) / sizeof(image_cycle[0])] = {false};
-static bool images_scanned = false;
+static const uint16_t metadata_image_cycle_length = sizeof(metadata_image_cycle) / sizeof(metadata_image_cycle[0]);
+static bool metadata_image_available[sizeof(metadata_image_cycle) / sizeof(metadata_image_cycle[0])] = {false};
+static bool metadata_images_scanned = false;
 static bool last_go_left = false;
 static bool last_go_right = false;
 
-static void scan_boxart_images(menu_t *menu) {
-    if (images_scanned) {
+static void scan_metadata_images(menu_t *menu) {
+    if (metadata_images_scanned) {
         return;
     }
 
@@ -48,6 +48,7 @@ static void scan_boxart_images(menu_t *menu) {
         path_pop(path);
     }
 
+    // This is deprecated, but keep for backwards compatibility
     if (!directory_exists(path_get(path))) {
         path_free(path);
         path = path_init(menu->storage_prefix, "menu/boxart");
@@ -61,7 +62,7 @@ static void scan_boxart_images(menu_t *menu) {
     bool dir_exists = directory_exists(path_get(path));
 
     if (dir_exists) {
-        // Filenames array matches image_cycle order for indexed access
+        // Filenames array matches metadata_image_cycle order for indexed access
         // Note: This mapping is also present in boxart.c but duplicated here
         // for efficient scanning without calling into the component layer
         char *filenames[] = {
@@ -75,20 +76,20 @@ static void scan_boxart_images(menu_t *menu) {
             "gamepak_back.png"
         };
 
-        for (int i = 0; i < image_cycle_length; i++) {
+        for (uint16_t i = 0; i < metadata_image_cycle_length; i++) {
             path_push(path, filenames[i]);
-            image_available[i] = file_exists(path_get(path));
+            metadata_image_available[i] = file_exists(path_get(path));
             path_pop(path);
         }
     } else {
         // No directory exists, mark all images as unavailable
-        for (int i = 0; i < image_cycle_length; i++) {
-            image_available[i] = false;
+        for (uint16_t i = 0; i < metadata_image_cycle_length; i++) {
+            metadata_image_available[i] = false;
         }
     }
 
     path_free(path);
-    images_scanned = true;
+    metadata_images_scanned = true;
 }
 
 static char *convert_error_message (rom_err_t err) {
@@ -281,39 +282,35 @@ static void add_favorite (menu_t *menu, void *arg) {
     bookkeeping_favorite_add(&menu->bookkeeping, menu->load.rom_path, NULL, BOOKKEEPING_TYPE_ROM);
 }
 
-static void cycle_image(menu_t *menu, int direction) {
-    scan_boxart_images(menu);
+static void cycle_metadata_image(menu_t *menu, int direction) {
+    scan_metadata_images(menu);
 
     // Cycle to next/previous available image based on direction (1 = next, -1 = previous)
-    int start_index = current_image_index;
-    int new_index = (current_image_index + direction + image_cycle_length) % image_cycle_length;
+    int16_t start_metadata_image_index = current_metadata_image_index;
+    int16_t new_metadata_image_index = (current_metadata_image_index + direction + metadata_image_cycle_length) % metadata_image_cycle_length;
 
     // Find next available image from our cached list
-    while (new_index != start_index) {
-        if (image_available[new_index]) {
+    while (new_metadata_image_index != start_metadata_image_index) {
+        if (metadata_image_available[new_metadata_image_index]) {
             // ui_components_boxart_init returns NULL if PNG decoder is busy
             component_boxart_t *new_boxart = ui_components_boxart_init(
                 menu->storage_prefix,
                 menu->load.rom_info.game_code,
                 menu->load.rom_info.title,
-                image_cycle[new_index]
+                metadata_image_cycle[new_metadata_image_index]
             );
 
             if (new_boxart != NULL) {
                 // Only free old boxart after successful new allocation
                 ui_components_boxart_free(boxart);
                 boxart = new_boxart;
-                current_image_index = new_index;
+                current_metadata_image_index = new_metadata_image_index;
                 sound_play_effect(SFX_SETTING);
                 break;
             }
         }
-        new_index = (new_index + direction + image_cycle_length) % image_cycle_length;
+        new_metadata_image_index = (new_metadata_image_index + direction + metadata_image_cycle_length) % metadata_image_cycle_length;
     }
-}
-
-static void cycle_image_next(menu_t *menu, void *arg) {
-    cycle_image(menu, 1);
 }
 
 static component_context_menu_t set_cic_type_context_menu = { .list = {
@@ -374,7 +371,6 @@ static void set_menu_next_mode (menu_t *menu, void *arg) {
 }
 
 static component_context_menu_t options_context_menu = { .list = {
-    { .text = "Cycle Next Image", .action = cycle_image_next },
     { .text = "Set CIC Type", .submenu = &set_cic_type_context_menu },
     { .text = "Set Save Type", .submenu = &set_save_type_context_menu },
     { .text = "Set TV Type", .submenu = &set_tv_type_context_menu },
@@ -410,15 +406,17 @@ static void process (menu_t *menu) {
             show_extra_info_message = true;
         }
         sound_play_effect(SFX_SETTING);
-    } else if (menu->actions.go_right && !menu->actions.go_fast && !last_go_right) {
-        cycle_image(menu, 1);
-    } else if (menu->actions.go_left && !menu->actions.go_fast && !last_go_left) {
-        cycle_image(menu, -1);
+    } else if (menu->actions.go_right && !last_go_right) {
+        cycle_metadata_image(menu, 1);
+        sound_play_effect(SFX_CURSOR);
+    } else if (menu->actions.go_left && !last_go_left) {
+        cycle_metadata_image(menu, -1);
+        sound_play_effect(SFX_CURSOR);
     }
 
     // Track button state for edge detection
-    last_go_left = menu->actions.go_left && !menu->actions.go_fast;
-    last_go_right = menu->actions.go_right && !menu->actions.go_fast;
+    last_go_left = menu->actions.go_left;
+    last_go_right = menu->actions.go_right;
 }
 
 static void draw (menu_t *menu, surface_t *d) {
@@ -597,14 +595,14 @@ static void load (menu_t *menu) {
 static void deinit (void) {
     ui_components_boxart_free(boxart);
     boxart = NULL;
-    current_image_index = 0;
-    images_scanned = false;
+    current_metadata_image_index = 0;
+    metadata_images_scanned = false;
     last_go_left = false;
     last_go_right = false;
 
     // Clear availability cache
-    for (int i = 0; i < image_cycle_length; i++) {
-        image_available[i] = false;
+    for (uint16_t i = 0; i < metadata_image_cycle_length; i++) {
+        metadata_image_available[i] = false;
     }
 }
 
@@ -645,7 +643,7 @@ void view_load_rom_init (menu_t *menu) {
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     if (!menu->settings.rom_autoload_enabled) {
 #endif
-        current_image_index = 0;
+        current_metadata_image_index = 0;
         boxart = ui_components_boxart_init(menu->storage_prefix, menu->load.rom_info.game_code, menu->load.rom_info.title, IMAGE_BOXART_FRONT);
         ui_components_context_menu_init(&options_context_menu);
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED


### PR DESCRIPTION
Currently load_rom only looks for the boxart_front, these changes add support for boxart_front, boxart-back, boxart_left, boxart_right, boxart_top, boxart_bottom, gamepak_front, and gamepak_right via cycling the existing image via dpad or menu

## Description
All updates are in load_rom.c. Added an image index to track current image. scan_boxart_images will check using the 4 digit code for which images are present for easy cycling (with fallback logic). I originally had it scanning the directory and preparing the files to cycle when loading rom_info, but there is pretty noticeable lag so I delayed it to the first time you attempt to cycle, since it feels like better UX to still load the screen ASAP in case you just want to jump into ROM loading.

## Motivation and Context
Documentation mentioned multiple boxarts, which I had loaded onto my SD card. When I realized only the first art was implemented, I wanted to give doing the rest a shot. This is my first contribution to the project and first time really doing much of anything in C, so all feedback either code or style is appreciated

## How Has This Been Tested?
<!-- (if applicable) -->
Testing has only been done on real hardware, I'm under the impression that this would not work in testing via Ares due to the SD card operations, but if this is not the case I'm happy to run through any other scenarios needed.

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [X] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: dpranker<dranker89@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image cycling added to ROM load view — use the D-pad to step forward/back; skips missing images and plays a navigation sound.
  * Support expanded for GamePak images: front and back plus left/right orientations.

* **Documentation**
  * Renamed "boxart" to "game art" and updated docs with new dimensions (158×112 for GamePak front/back) and explicit storage location (sd:/menu/metadata/).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->