### PR TITLE
[Develop] Fix Neon64 saves

### DIFF
--- a/docs/18_emulators.md
+++ b/docs/18_emulators.md
@@ -2,7 +2,7 @@
 N64FlashcartMenu supports multiple emulators that are compatible with the N64. At the time of writing, current emulator support includes NES, SNES, GB, GBC, SMS, GG, and CHF ROMs.
 
 Emulators should be added to the `/menu/emulators` directory on the SD card. N64FlashcartMenu currently supports the following emulators and associated ROM file names:
-- **NES**: [Neon64 v1.2/v0.3c](https://hcs64.com/neon64.html) by *visor / hcs64* - `neon64bu.rom`
+- **NES**: [Neon64 v1.2/v0.3c/v2](https://github.com/hcs64/neon64v2/releases) by *visor / hcs64* - `neon64bu.rom`
 - **SNES**: [sodium64](https://github.com/Hydr8gon/sodium64/releases) by *Hydr8gon* - `sodium64.z64`
 - **Game Boy**/**GB Color**: [gb64](https://lambertjamesd.github.io/gb64/romwrapper/romwrapper.html) by *lambertjamesd* - `gb.v64`/`gbc.v64` ("Download Emulator" button)
 - **SMS**/**GG**: [smsPlus64](https://github.com/fhoedemakers/smsplus64/releases) by *fhoedmakers* - `smsPlus64.z64`
@@ -10,8 +10,5 @@ Emulators should be added to the `/menu/emulators` directory on the SD card. N64
 
 > [!WARNING]
 > **NES**: [Neon64 v1.2/v0.3c](https://hcs64.com/neon64.html) in-game autosaves may fail (work around using save states).
-
-> [!WARNING]
-> **NES**: [neon64 v2 beta releases](https://github.com/hcs64/neon64v2/releases) by *hcs64* currently have issues with saves. 
 
 If you are an emulator developer and are interested in adding your emulator, take a look at this [template pull request](https://github.com/Polprzewodnikowy/N64FlashcartMenu/pull/178).

--- a/src/menu/cart_load.c
+++ b/src/menu/cart_load.c
@@ -220,9 +220,8 @@ cart_load_err_t cart_load_emulator (menu_t *menu, cart_load_emu_type_t emu_type,
     switch (emu_type) {
         case CART_LOAD_EMU_TYPE_NES:
             path_push(path, "neon64bu.rom");
-             // Tested against https://themanbehindcurtain.blogspot.com/2017/12/small-neon64-hdmi-audio-fix.html
-             // Save states in newer versions might require a different save type.
-            save_type = FLASHCART_SAVE_TYPE_SRAM_BANKED;
+             // Tested against Neon 64 v1.2, v0.3 and v2
+            save_type = FLASHCART_SAVE_TYPE_SRAM_1MBIT;
             break;
         case CART_LOAD_EMU_TYPE_SNES:
             path_push(path, "sodium64.z64");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When saving on neon64 (NES emulator) saves failed on v2. changing savetype makes it work and can also be used with older versions

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Real N64 using Neon64 v1.2a, v0.3 and v2

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
