### PR TITLE
[Develop] Add Virtual Controller Pak system for per-game pak management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ SRCS = \
 	menu/rom_info.c \
 	menu/settings.c \
 	menu/sound.c \
+	menu/virtual_cpak.c \
 	menu/ui_components/background.c \
 	menu/ui_components/boxart.c \
 	menu/ui_components/common.c \
@@ -84,6 +85,8 @@ SRCS = \
 	menu/views/cpakfs_manager.c \
 	menu/views/cpak_dump_info.c \
 	menu/views/cpak_note_dump_info.c \
+	menu/views/vcpak_select.c \
+	menu/views/vcpak_recovery.c \
 	utils/cpakfs_utils.c \
 	utils/fs.c
 

--- a/docs/15_controller_paks.md
+++ b/docs/15_controller_paks.md
@@ -1,10 +1,83 @@
 ## Controller Paks
 This feature still relies on a controller PAK being "plugged in" to a physical controller (port). The N64 hardware **CANNOT** emulate it from a flashcart.
 
+The N64FlashcartMenu provides comprehensive Controller Pak management, including automatic per-game virtual pak saves.
+
+---
+
+### Virtual Controller Pak System
+
+The Virtual Controller Pak system automatically manages Controller Pak saves on a per-game basis. This means each game can have its own dedicated save data without manually swapping physical paks or worrying about save conflicts between games.
+
+This feature is disabled by default. To enable it, go to **Settings** and turn on **Virtual CPak**.
+
+#### How It Works
+
+1. **Game Launch**: When you launch a game that supports Controller Pak saves, you'll be prompted to select a virtual pak
+2. **Pak Selection**: Choose an existing pak or create a new one for that game
+3. **Automatic Restore**: The selected pak's data is written to your physical Controller Pak before the game boots
+4. **Automatic Backup**: When you return to the menu (via reset), any changes are automatically saved back to the virtual pak file
+
+#### Directory Structure
+
+Virtual pak files are stored on your SD card:
+```
+SD:/cpak_saves/
+├── NHXE/                    # Game code directory (e.g., Hexen)
+│   ├── Hexen_001.pak        # First pak for this game
+│   └── Hexen_002.pak        # Second pak for this game
+├── NDYE/                    # Game code directory (e.g., Diddy Kong Racing)
+│   └── DiddyKongRacing_001.pak
+└── ...
+```
+
+Each game has its own subdirectory based on its 4-character game code. Pak files are named after the game title with a numeric suffix.
+
+#### Pak Selection Screen
+
+When launching a Controller Pak game, you'll see the pak selection screen:
+
+- **[Create New Controller Pak]** - Creates a fresh, empty pak for this game
+- **Existing paks** - Listed below, with `*` marking the last-used pak
+- **A Button** - Select/confirm
+- **B Button** - Cancel (return to ROM info)
+- **R Button** - Delete selected pak
+
+#### Power Loss Recovery
+
+The system tracks "dirty state" to handle unexpected power loss:
+
+1. Before booting a game, a state file records which pak is in use
+2. If power is lost during gameplay, this state persists
+3. On next boot, the menu detects the dirty state and:
+   - If a physical pak is present: automatically backs up the pak contents
+   - If no physical pak: shows a recovery dialog
+
+This ensures save data is not lost even if you forget to return to the menu before powering off.
+
+#### Requirements
+
+- A physical Controller Pak must be inserted in Port 1 for saves to work
+- If no Controller Pak is detected, a warning is shown but you can still launch the game
+
+#### Error Handling
+
+The system will show an error and prevent game launch if:
+- The pak file cannot be created (disk full, permission error)
+- The pak directory cannot be created
+- The pak file cannot be read or is corrupted
+- The pak file is too large for the physical device
+
+This prevents launching a game with stale or incorrect save data on the physical pak.
+
+---
+
+### Controller Pak Manager
+
 > [!WARNING]
 > **THIS FEATURE IS EXPERIMENTAL**
 
-The N64FlashcartMenu has a Controller Pak Manager accessed from the `Start` button within the main file browser.
+The N64FlashcartMenu also includes a manual Controller Pak Manager for direct pak manipulation, accessed from the `Start` button within the main file browser.
 
 > [!CAUTION]
 > Mileage may vary when hot swapping paks without exiting and re-entering the screen (and may contain incorrect content), and/or re-powering the console.
@@ -14,9 +87,22 @@ Features:
 - Partial pak ('note') backup and restore (saved to `SD:/cpak_saves/notes/`).
 
 
-### Controller Pak Manager
-Use the "Controller Pak Manager" (accessed using `Start` button ) to backup and manage the pak (including full backups or individual notes).
-![Backup Controller Pak](./images/cpak-manager.png "Backup Controller Pak confirmation") 
+#### Using the Controller Pak Manager
+Use the "Controller Pak Manager" (accessed using `Start` button) to backup and manage the pak (including full backups or individual notes).
+![Backup Controller Pak](./images/cpak-manager.png "Backup Controller Pak confirmation")
 
 #### Restoring saves
 To restore full backups or individual notes, browse to the saved file (usually contained within `SD:/cpak_saves/`) and follow the menu instructions.
+
+---
+
+### Troubleshooting
+
+#### "Controller Pak file not found" error
+This occurs if the pak file was not successfully created. Check that:
+- Your SD card has free space
+- The SD card is not write-protected
+- The `/cpak_saves/` directory is accessible
+
+#### Saves not persisting between sessions
+Ensure you return to the menu via the reset button rather than just powering off. While the dirty state recovery should handle power loss, using reset ensures immediate backup.

--- a/docs/32_menu_settings.md
+++ b/docs/32_menu_settings.md
@@ -13,6 +13,9 @@ OFF: ROM saves are saved alongside the ROM file.
 ### Sound Effects
 The menu has default sound effects to improve the user experience. See the [sound documentation](./40_sound.md) for details. This setting is OFF by default.
 
+### Virtual CPak
+Enables the Virtual Controller Pak system for automatic per-game Controller Pak save management. See the [controller paks documentation](./15_controller_paks.md) for details. This setting is OFF by default.
+
 ### Fast ROM reboots
 Certain flashcarts support the ability to use the N64 `RESET` button for re-loading the last game, rather than returning to the menu. When enabled (and if supported by your flashcart), the power switch must be toggled to return to the menu.  
 

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -198,7 +198,9 @@ static view_t menu_views[] = {
     { MENU_MODE_FAVORITE, view_favorite_init, view_favorite_display },
     { MENU_MODE_HISTORY, view_history_init, view_history_display },
     { MENU_MODE_DATEL_CODE_EDITOR, view_datel_code_editor_init, view_datel_code_editor_display },
-    { MENU_MODE_EXTRACT_FILE, view_extract_file_init, view_extract_file_display }
+    { MENU_MODE_EXTRACT_FILE, view_extract_file_init, view_extract_file_display },
+    { MENU_MODE_VCPAK_SELECT, view_vcpak_select_init, view_vcpak_select_display },
+    { MENU_MODE_VCPAK_RECOVERY, view_vcpak_recovery_init, view_vcpak_recovery_display }
 };
 
 /**

--- a/src/menu/menu_state.h
+++ b/src/menu/menu_state.h
@@ -47,7 +47,9 @@ typedef enum {
     MENU_MODE_FAVORITE,
     MENU_MODE_HISTORY,
     MENU_MODE_DATEL_CODE_EDITOR,
-    MENU_MODE_EXTRACT_FILE
+    MENU_MODE_EXTRACT_FILE,
+    MENU_MODE_VCPAK_SELECT,
+    MENU_MODE_VCPAK_RECOVERY
 } menu_mode_t;
 
 /** @brief File entry type enumeration */
@@ -134,6 +136,9 @@ typedef struct {
         int32_t load_history_id;
         int32_t load_favorite_id;
         bool combined_disk_rom;
+        bool vcpak_enabled;
+        char vcpak_selected[256];
+        bool vcpak_no_physical;
     } load;
 
     struct {

--- a/src/menu/rom_info.c
+++ b/src/menu/rom_info.c
@@ -765,6 +765,7 @@ static void extract_rom_info (match_t *match, rom_header_t *rom_header, rom_info
 
     rom_info->settings.cheats_enabled = false;
     rom_info->settings.patches_enabled = false;
+    rom_info->settings.last_cpak_file[0] = '\0';
 }
 
 static void load_rom_meta_from_file (path_t *path, rom_info_t *rom_info) {
@@ -804,6 +805,11 @@ static void load_rom_config_from_file (path_t *path, rom_info_t *rom_info) {
         // general
         rom_info->settings.cheats_enabled = mini_get_bool(rom_config_ini, NULL, "cheats_enabled", false);
         rom_info->settings.patches_enabled = mini_get_bool(rom_config_ini, NULL, "patches_enabled", false);
+
+        // virtual controller pak
+        const char *last_cpak = mini_get_string(rom_config_ini, NULL, "last_cpak_file", "");
+        strncpy(rom_info->settings.last_cpak_file, last_cpak, sizeof(rom_info->settings.last_cpak_file) - 1);
+        rom_info->settings.last_cpak_file[sizeof(rom_info->settings.last_cpak_file) - 1] = '\0';
         
         // overrides
         rom_info->boot_override.cic_type = mini_get_int(rom_config_ini, "custom_boot", "cic_type", ROM_CIC_TYPE_AUTOMATIC);
@@ -827,54 +833,71 @@ static void load_rom_config_from_file (path_t *path, rom_info_t *rom_info) {
     path_free(rom_info_path);
 }
 
+/**
+ * @brief Helper to finalize INI save: save if non-empty, remove if empty, cleanup resources.
+ */
+static rom_err_t rom_config_finalize_save(mini_t *ini, path_t *ini_path, int mini_err) {
+    if ((mini_err != MINI_OK) && (mini_err != MINI_VALUE_NOT_FOUND)) {
+        path_free(ini_path);
+        mini_free(ini);
+        return ROM_ERR_SAVE_IO;
+    }
+
+    bool empty = mini_empty(ini);
+
+    if (!empty) {
+        if (mini_save(ini, MINI_FLAGS_NONE) != MINI_OK) {
+            path_free(ini_path);
+            mini_free(ini);
+            return ROM_ERR_SAVE_IO;
+        }
+    }
+
+    mini_free(ini);
+
+    if (empty) {
+        if (remove(path_get(ini_path)) && (errno != ENOENT)) {
+            path_free(ini_path);
+            return ROM_ERR_SAVE_IO;
+        }
+    }
+
+    path_free(ini_path);
+    return ROM_OK;
+}
+
 static rom_err_t save_rom_config_setting_to_file (path_t *path, const char *type, const char *id, int value, int default_value) {
     path_t *rom_info_path = path_clone(path);
-
     path_ext_replace(rom_info_path, "ini");
 
     mini_t *rom_config_ini = mini_try_load(path_get(rom_info_path));
-
     if (!rom_config_ini) {
         path_free(rom_info_path);
         return ROM_ERR_SAVE_IO;
     }
 
-    int mini_err;
+    int mini_err = (value == default_value)
+        ? mini_delete_value(rom_config_ini, type, id)
+        : mini_set_int(rom_config_ini, type, id, value);
 
-    if (value == default_value) {
-        mini_err = mini_delete_value(rom_config_ini, type, id);
-    } else {
-        mini_err = mini_set_int(rom_config_ini, type, id, value);
-    }
+    return rom_config_finalize_save(rom_config_ini, rom_info_path, mini_err);
+}
 
-    if ((mini_err != MINI_OK) && (mini_err != MINI_VALUE_NOT_FOUND)) {
+static rom_err_t save_rom_config_setting_string_to_file (path_t *path, const char *type, const char *id, const char *value) {
+    path_t *rom_info_path = path_clone(path);
+    path_ext_replace(rom_info_path, "ini");
+
+    mini_t *rom_config_ini = mini_try_load(path_get(rom_info_path));
+    if (!rom_config_ini) {
         path_free(rom_info_path);
-        mini_free(rom_config_ini);
         return ROM_ERR_SAVE_IO;
     }
 
-    bool empty = mini_empty(rom_config_ini);
+    int mini_err = (value == NULL || value[0] == '\0')
+        ? mini_delete_value(rom_config_ini, type, id)
+        : mini_set_string(rom_config_ini, type, id, value);
 
-    if (!empty) {
-        if (mini_save(rom_config_ini, MINI_FLAGS_NONE) != MINI_OK) {
-            path_free(rom_info_path);
-            mini_free(rom_config_ini);
-            return ROM_ERR_SAVE_IO;
-        }
-    }
-
-    mini_free(rom_config_ini);
-
-    if (empty) {
-        if (remove(path_get(rom_info_path)) && (errno != ENOENT)) {
-            path_free(rom_info_path);
-            return ROM_ERR_SAVE_IO;
-        }
-    }
-
-    path_free(rom_info_path);
-
-    return ROM_OK;
+    return rom_config_finalize_save(rom_config_ini, rom_info_path, mini_err);
 }
 
 
@@ -951,6 +974,16 @@ rom_err_t rom_config_override_tv_type (path_t *path, rom_info_t *rom_info, rom_t
 rom_err_t rom_config_setting_set_cheats (path_t *path, rom_info_t *rom_info, bool enabled) {
     rom_info->settings.cheats_enabled = enabled;
     return save_rom_config_setting_to_file(path, NULL, "cheats_enabled", enabled, false);
+}
+
+rom_err_t rom_config_setting_set_last_cpak (path_t *path, rom_info_t *rom_info, const char *cpak_filename) {
+    if (cpak_filename) {
+        strncpy(rom_info->settings.last_cpak_file, cpak_filename, sizeof(rom_info->settings.last_cpak_file) - 1);
+        rom_info->settings.last_cpak_file[sizeof(rom_info->settings.last_cpak_file) - 1] = '\0';
+    } else {
+        rom_info->settings.last_cpak_file[0] = '\0';
+    }
+    return save_rom_config_setting_string_to_file(path, NULL, "last_cpak_file", cpak_filename);
 }
 
 #ifdef FEATURE_PATCHER_GUI_ENABLED

--- a/src/menu/rom_info.h
+++ b/src/menu/rom_info.h
@@ -162,6 +162,7 @@ typedef struct {
     struct {
         bool cheats_enabled;        /**< Cheats enabled */
         bool patches_enabled;       /**< Patches enabled */
+        char last_cpak_file[64];    /**< Last used virtual Controller Pak filename */
     } settings;                     /**< The ROM settings */
 
     struct {
@@ -256,6 +257,16 @@ rom_err_t rom_config_override_tv_type(path_t *path, rom_info_t *rom_info, rom_tv
  * @return rom_err_t Error code
  */
 rom_err_t rom_config_setting_set_cheats (path_t *path, rom_info_t *rom_info, bool enabled);
+
+/**
+ * @brief Set the last used Controller Pak file for the ROM.
+ *
+ * @param path Pointer to the path structure
+ * @param rom_info Pointer to the ROM information structure
+ * @param cpak_filename The filename of the last used virtual Controller Pak
+ * @return rom_err_t Error code
+ */
+rom_err_t rom_config_setting_set_last_cpak(path_t *path, rom_info_t *rom_info, const char *cpak_filename);
 
 #ifdef FEATURE_PATCHER_GUI_ENABLED
 /**

--- a/src/menu/settings.c
+++ b/src/menu/settings.c
@@ -31,6 +31,7 @@ static settings_t init = {
     .show_browser_rom_tags = true,
     .bgm_enabled = false,
     .rumble_enabled = false,
+    .virtual_cpak_enabled = false,
 };
 
 
@@ -57,7 +58,8 @@ void settings_load (settings_t *settings) {
     settings->use_saves_folder = mini_get_bool(ini, "menu", "use_saves_folder", init.use_saves_folder);
     settings->show_saves_folder = mini_get_bool(ini, "menu", "show_saves_folder", init.show_saves_folder);
     settings->soundfx_enabled = mini_get_bool(ini, "menu", "soundfx_enabled", init.soundfx_enabled);
-    
+    settings->virtual_cpak_enabled = mini_get_bool(ini, "menu", "virtual_cpak_enabled", init.virtual_cpak_enabled);
+
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     settings->rom_autoload_enabled = mini_get_bool(ini, "menu", "autoload_rom_enabled", init.rom_autoload_enabled);
     settings->rom_autoload_path = strdup(mini_get_string(ini, "autoload", "rom_path", init.rom_autoload_path));
@@ -87,6 +89,7 @@ void settings_save (settings_t *settings) {
     mini_set_bool(ini, "menu", "use_saves_folder", settings->use_saves_folder);
     mini_set_bool(ini, "menu", "show_saves_folder", settings->show_saves_folder);
     mini_set_bool(ini, "menu", "soundfx_enabled", settings->soundfx_enabled);
+    mini_set_bool(ini, "menu", "virtual_cpak_enabled", settings->virtual_cpak_enabled);
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     mini_set_bool(ini, "menu", "autoload_rom_enabled", settings->rom_autoload_enabled);
     mini_set_string(ini, "autoload", "rom_path", settings->rom_autoload_path);

--- a/src/menu/settings.h
+++ b/src/menu/settings.h
@@ -49,6 +49,9 @@ typedef struct {
     /** @brief Enable rumble feedback within the menu */
     bool rumble_enabled;
 
+    /** @brief Enable Virtual Controller Pak system for per-game pak management */
+    bool virtual_cpak_enabled;
+
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     /** @brief Show progress bar when loading a ROM */
     bool loading_progress_bar_enabled;

--- a/src/menu/views/cpak_dump_info.c
+++ b/src/menu/views/cpak_dump_info.c
@@ -13,8 +13,6 @@ static int16_t controller_selected;
 static char failure_message[255];
 static bool start_complete_restore;
 
-#define CONTROLLERPAK_BANK_SIZE 32768
-
 static bool restore_controller_pak(int controller) {
     sprintf(failure_message, " ");
 
@@ -25,7 +23,7 @@ static bool restore_controller_pak(int controller) {
 
     cpakfs_unmount(controller);
 
-    uint8_t *data = malloc(CONTROLLERPAK_BANK_SIZE);
+    uint8_t *data = malloc(CPAK_BANK_SIZE);
     if (!data) {
         sprintf(failure_message, "Memory allocation failed!");
         return false;
@@ -53,7 +51,7 @@ static bool restore_controller_pak(int controller) {
     }
     rewind(fp);
 
-    int total_banks = (int)((filesize + CONTROLLERPAK_BANK_SIZE - 1) / CONTROLLERPAK_BANK_SIZE);
+    int total_banks = (int)((filesize + CPAK_BANK_SIZE - 1) / CPAK_BANK_SIZE);
 
     int banks_on_device = cpak_probe_banks(controller);
     if (banks_on_device < 1) {
@@ -73,7 +71,7 @@ static bool restore_controller_pak(int controller) {
     debugf("Restoring Controller Pak: %ld bytes (%d banks)\n", filesize, total_banks);
 
     for (int bank = 0; bank < total_banks; bank++) {
-        size_t bytesRead = fread(data, 1, CONTROLLERPAK_BANK_SIZE, fp);
+        size_t bytesRead = fread(data, 1, CPAK_BANK_SIZE, fp);
         if (bytesRead == 0 && ferror(fp)) {
             sprintf(failure_message, "Read error from dump file!");
             fclose(fp);

--- a/src/menu/views/cpakfs_manager.c
+++ b/src/menu/views/cpakfs_manager.c
@@ -250,6 +250,10 @@ static void dump_complete_cpak(int port) {
         case CPAK_IO_OK:
             process_complete_full_dump = true;
             return;
+        case CPAK_IO_ERR_NO_PAK:
+            sprintf(failure_message_note, "No Controller Pak detected in port %d!", port + 1);
+            error_message_displayed = true;
+            return;
         case CPAK_IO_ERR_ALLOC:
             sprintf(failure_message_note, "Memory allocation failed!");
             error_message_displayed = true;

--- a/src/menu/views/cpakfs_manager.c
+++ b/src/menu/views/cpakfs_manager.c
@@ -11,8 +11,6 @@
 
 #define MAX_STRING_LENGTH 62
 
-#define MEMPAK_BANK_SIZE 32768
-
 #define CPAK_EXTENSION ".pak"   
 #define CPAK_NOTE_EXTENSION ".paknote"
 
@@ -259,7 +257,7 @@ static void dump_complete_cpak(int port) {
         return;
     }
 
-    uint8_t *bankbuf = malloc(MEMPAK_BANK_SIZE);
+    uint8_t *bankbuf = malloc(CPAK_BANK_SIZE);
     if (!bankbuf) {
         sprintf(failure_message_note, "Memory allocation failed!");
         error_message_displayed = true;
@@ -268,8 +266,8 @@ static void dump_complete_cpak(int port) {
     }
 
     for (int b = 0; b < banks; ++b) {
-        int rd = cpak_read((joypad_port_t)port, (uint8_t)b, 0, bankbuf, MEMPAK_BANK_SIZE);
-        if (rd < 0 || rd != MEMPAK_BANK_SIZE) {
+        int rd = cpak_read((joypad_port_t)port, (uint8_t)b, 0, bankbuf, CPAK_BANK_SIZE);
+        if (rd < 0 || rd != CPAK_BANK_SIZE) {
             sprintf(failure_message_note, "Failed to read Controller Pak bank %d (err=%d)", b, (rd < 0) ? errno : -1);
             error_message_displayed = true;
             free(bankbuf);
@@ -277,8 +275,8 @@ static void dump_complete_cpak(int port) {
             return;
         }
 
-        size_t wr = fwrite(bankbuf, 1, MEMPAK_BANK_SIZE, fp);
-        if (wr != MEMPAK_BANK_SIZE) {
+        size_t wr = fwrite(bankbuf, 1, CPAK_BANK_SIZE, fp);
+        if (wr != CPAK_BANK_SIZE) {
             sprintf(failure_message_note, "Failed to write data to file: %s", complete_filename);
             error_message_displayed = true;
             free(bankbuf);

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -3,10 +3,13 @@
 #include "../datel_codes.h"
 #include "../rom_info.h"
 #include "../sound.h"
+#include "../virtual_cpak.h"
 #include "boot/boot.h"
 #include "utils/fs.h"
+#include "utils/cpakfs_utils.h"
 #include "views.h"
 #include <string.h>
+#include <time.h>
 
 static bool show_extra_info_message = false;
 static component_boxart_t *boxart;
@@ -423,7 +426,13 @@ static void process (menu_t *menu) {
     }
 
     if (menu->actions.enter) {
-        menu->load_pending.rom_file = true;
+        if (menu->settings.virtual_cpak_enabled && menu->load.rom_info.features.controller_pak) {
+            // Game supports Controller Pak and virtual cpak is enabled - redirect to pak selection
+            sound_play_effect(SFX_ENTER);
+            menu->next_mode = MENU_MODE_VCPAK_SELECT;
+        } else {
+            menu->load_pending.rom_file = true;
+        }
     } else if (menu->actions.back) {
         sound_play_effect(SFX_EXIT);
         menu->next_mode = MENU_MODE_BROWSER;
@@ -568,6 +577,71 @@ static void draw_progress (float progress) {
 
 static void load (menu_t *menu) {
     debugf("Load ROM: load function called\n");
+
+    // Handle Virtual Controller Pak restore before ROM load
+    if (menu->load.vcpak_enabled) {
+        debugf("Load ROM: Virtual Controller Pak enabled\n");
+
+        // Restore pak contents to physical device
+        // For new paks, this writes the empty pak to clear the physical device
+        // For existing paks, this restores previously saved data
+        debugf("Load ROM: Restoring pak from %s\n", menu->load.vcpak_selected);
+        vcpak_err_t pak_err = vcpak_restore_to_physical(menu->load.vcpak_selected, 0);
+        if (pak_err != VCPAK_OK) {
+            debugf("Load ROM: pak restore failed with error %d\n", pak_err);
+            if (pak_err == VCPAK_ERR_NO_CPAK) {
+                // No physical pak - user was already warned, continue anyway
+                debugf("Load ROM: No physical pak detected, continuing without restore\n");
+            } else {
+                // Serious error - pak file missing, I/O error, or corruption
+                // Do NOT boot the game as the physical pak contains stale data
+                char *err_msg;
+                switch (pak_err) {
+                    case VCPAK_ERR_FILE_NOT_FOUND:
+                        err_msg = "Controller Pak file not found.\nThe pak may not have been created.";
+                        break;
+                    case VCPAK_ERR_IO:
+                        err_msg = "I/O error reading Controller Pak file.";
+                        break;
+                    case VCPAK_ERR_CORRUPTED:
+                        err_msg = "Controller Pak file is corrupted.";
+                        break;
+                    case VCPAK_ERR_ALLOC:
+                        err_msg = "Out of memory restoring Controller Pak.";
+                        break;
+                    case VCPAK_ERR_TOO_LARGE:
+                        err_msg = "Controller Pak file too large for device.";
+                        break;
+                    default:
+                        err_msg = "Failed to restore Controller Pak.";
+                        break;
+                }
+                menu_show_error(menu, err_msg);
+                return;
+            }
+        }
+
+        // Save dirty state so we can recover if power is lost
+        vcpak_state_t state;
+        memset(&state, 0, sizeof(state));
+        state.magic = VCPAK_STATE_MAGIC;
+        strncpy(state.game_code, menu->load.rom_info.game_code, sizeof(state.game_code) - 1);
+        state.game_code[sizeof(state.game_code) - 1] = '\0';
+        strncpy(state.game_title, menu->load.rom_info.title, sizeof(state.game_title) - 1);
+        state.game_title[sizeof(state.game_title) - 1] = '\0';
+        strncpy(state.rom_path, path_get(menu->load.rom_path), sizeof(state.rom_path) - 1);
+        state.rom_path[sizeof(state.rom_path) - 1] = '\0';
+        strncpy(state.pak_path, menu->load.vcpak_selected, sizeof(state.pak_path) - 1);
+        state.pak_path[sizeof(state.pak_path) - 1] = '\0';
+        state.timestamp = (uint32_t)time(NULL);
+        state.is_dirty = 1;
+
+        vcpak_err_t state_err = vcpak_state_save(menu->storage_prefix, &state);
+        if (state_err != VCPAK_OK) {
+            debugf("Load ROM: Warning - failed to save dirty state\n");
+        }
+    }
+
     cart_load_err_t err;
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     if (!menu->settings.loading_progress_bar_enabled) {
@@ -694,7 +768,7 @@ void view_load_rom_display (menu_t *menu, surface_t *display) {
         load(menu);
     }
 
-    if (menu->next_mode != MENU_MODE_LOAD_ROM && menu->next_mode != MENU_MODE_DATEL_CODE_EDITOR) {
+    if (menu->next_mode != MENU_MODE_LOAD_ROM && menu->next_mode != MENU_MODE_DATEL_CODE_EDITOR && menu->next_mode != MENU_MODE_VCPAK_SELECT) {
         menu->load.load_history_id = -1;
         menu->load.load_favorite_id = -1;
         deinit();

--- a/src/menu/views/settings_editor.c
+++ b/src/menu/views/settings_editor.c
@@ -49,6 +49,11 @@ static void set_pal60_type (menu_t *menu, void *arg) {
     settings_save(&menu->settings);
 }
 
+static void set_virtual_cpak_enabled_type (menu_t *menu, void *arg) {
+    menu->settings.virtual_cpak_enabled = (bool)(uintptr_t)(arg);
+    settings_save(&menu->settings);
+}
+
 #ifndef FEATURE_AUTOLOAD_ROM_ENABLED
 static void set_use_rom_fast_reboot_enabled_type (menu_t *menu, void *arg) {
     menu->settings.rom_fast_reboot_enabled = (bool)(uintptr_t)(arg);
@@ -119,6 +124,18 @@ static component_context_menu_t set_soundfx_enabled_type_context_menu = {
     .list = {
         {.text = "On", .action = set_soundfx_enabled_type, .arg = (void *)(uintptr_t)(true) },
         {.text = "Off", .action = set_soundfx_enabled_type, .arg = (void *)(uintptr_t)(false) },
+    COMPONENT_CONTEXT_MENU_LIST_END,
+}};
+
+static int get_virtual_cpak_enabled_current_selection (menu_t *menu) {
+    return menu->settings.virtual_cpak_enabled ? 0 : 1;
+}
+
+static component_context_menu_t set_virtual_cpak_enabled_type_context_menu = {
+    .get_default_selection = get_virtual_cpak_enabled_current_selection,
+    .list = {
+        {.text = "On", .action = set_virtual_cpak_enabled_type, .arg = (void *)(uintptr_t)(true) },
+        {.text = "Off", .action = set_virtual_cpak_enabled_type, .arg = (void *)(uintptr_t)(false) },
     COMPONENT_CONTEXT_MENU_LIST_END,
 }};
 
@@ -228,7 +245,8 @@ static component_context_menu_t options_context_menu = { .list = {
     { .text = "Use Saves Folder", .submenu = &set_use_saves_folder_type_context_menu },
     { .text = "Show Saves Folder", .submenu = &set_show_saves_folder_type_context_menu },
     { .text = "PAL60 Mode", .submenu = &set_pal60_type_context_menu },
-    #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
+    { .text = "Virtual CPak", .submenu = &set_virtual_cpak_enabled_type_context_menu },
+#ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     { .text = "ROM Loading Bar", .submenu = &set_loading_progress_bar_enabled_context_menu },
 #else
     { .text = "Fast Reboot ROM", .submenu = &set_use_rom_fast_reboot_context_menu },
@@ -296,6 +314,7 @@ static void draw (menu_t *menu, surface_t *d) {
         "     Use Saves folder  : %s\n"
         "     Show Saves folder : %s\n"
         "*    PAL60 Mode        : %s\n"
+        "     Virtual CPak      : %s\n"
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
         "     Autoload ROM      : %s\n\n"
         "     ROM Loading Bar   : %s\n"
@@ -317,6 +336,7 @@ static void draw (menu_t *menu, surface_t *d) {
         format_switch(menu->settings.use_saves_folder),
         format_switch(menu->settings.show_saves_folder),
         format_switch(menu->settings.pal60_enabled),
+        format_switch(menu->settings.virtual_cpak_enabled),
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
         format_switch(menu->settings.rom_autoload_enabled),
         format_switch(menu->settings.loading_progress_bar_enabled)

--- a/src/menu/views/startup.c
+++ b/src/menu/views/startup.c
@@ -1,5 +1,8 @@
-#include "utils/fs.h"
+#include <libdragon.h>
+
 #include "views.h"
+#include "../virtual_cpak.h"
+#include "utils/cpakfs_utils.h"
 
 
 static void draw (menu_t *menu, surface_t *d) {
@@ -9,6 +12,33 @@ static void draw (menu_t *menu, surface_t *d) {
 
 
 void view_startup_init (menu_t *menu) {
+    // Check for dirty Virtual Controller Pak state (unclean exit from previous game)
+    // Only if virtual cpak feature is enabled
+    if (menu->settings.virtual_cpak_enabled) {
+        vcpak_state_t dirty_state;
+        if (vcpak_state_load(menu->storage_prefix, &dirty_state) == VCPAK_OK && dirty_state.is_dirty) {
+            debugf("Startup: Detected dirty vcpak state from previous session\n");
+
+            // Check if physical pak is present
+            if (has_cpak(0)) {
+                // Physical pak present - auto-backup and clear state
+                debugf("Startup: Physical pak detected, auto-backing up to %s\n", dirty_state.pak_path);
+                vcpak_err_t err = vcpak_backup_from_physical(dirty_state.pak_path, 0);
+                if (err == VCPAK_OK) {
+                    debugf("Startup: Auto-backup successful\n");
+                } else {
+                    debugf("Startup: Auto-backup failed with error %d\n", err);
+                }
+                vcpak_state_clear(menu->storage_prefix);
+            } else {
+                // No physical pak - show recovery dialog
+                debugf("Startup: No physical pak, showing recovery dialog\n");
+                menu->next_mode = MENU_MODE_VCPAK_RECOVERY;
+                return;
+            }
+        }
+    }
+
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     // FIXME: rather than use a controller button, would it be better to use the cart button?
     JOYPAD_PORT_FOREACH (port) {

--- a/src/menu/views/vcpak_recovery.c
+++ b/src/menu/views/vcpak_recovery.c
@@ -1,0 +1,222 @@
+/**
+ * @file vcpak_recovery.c
+ * @brief Virtual Controller Pak recovery view.
+ * @ingroup view
+ *
+ * This view is shown when the menu detects a dirty state from a previous
+ * session, indicating an unclean exit (e.g., power loss). It prompts the
+ * user to backup the current Controller Pak contents.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <libdragon.h>
+
+#include "views.h"
+#include "../sound.h"
+#include "../fonts.h"
+#include "../virtual_cpak.h"
+#include "utils/cpakfs_utils.h"
+
+
+static vcpak_state_t dirty_state;
+static bool state_loaded;
+static bool backup_pending;      // User requested backup, needs to be performed
+static bool show_backing_up;     // Currently displaying "backing up" message
+static bool show_backup_result;
+static bool backup_success;
+static bool no_physical_pak;
+
+static void process(menu_t *menu) {
+    // If showing backup result, wait for acknowledgment
+    if (show_backup_result) {
+        if (menu->actions.enter || menu->actions.back) {
+            sound_play_effect(SFX_ENTER);
+            // Clear dirty state and proceed to startup
+            vcpak_state_clear(menu->storage_prefix);
+            menu->next_mode = MENU_MODE_STARTUP;
+        }
+        return;
+    }
+
+    // Perform backup if pending (after "backing up" message was shown)
+    if (backup_pending) {
+        vcpak_err_t err = vcpak_backup_from_physical(dirty_state.pak_path, 0);
+        backup_success = (err == VCPAK_OK);
+        backup_pending = false;
+        show_backing_up = false;
+        show_backup_result = true;
+        return;
+    }
+
+    // If showing "backing up" message, set pending flag for next frame
+    if (show_backing_up) {
+        backup_pending = true;
+        return;
+    }
+
+    // Normal dialog handling
+    if (menu->actions.enter) {
+        // "Update Pak Now" - backup current pak contents
+        sound_play_effect(SFX_ENTER);
+
+        if (no_physical_pak) {
+            // Can't backup without physical pak
+            backup_success = false;
+            show_backup_result = true;
+        } else {
+            show_backing_up = true;
+        }
+    } else if (menu->actions.back) {
+        // "Discard Changes" - just clear state and continue
+        sound_play_effect(SFX_EXIT);
+        vcpak_state_clear(menu->storage_prefix);
+        menu->next_mode = MENU_MODE_STARTUP;
+    }
+}
+
+static void draw(menu_t *menu, surface_t *d) {
+    rdpq_attach(d, NULL);
+
+    ui_components_background_draw();
+    ui_components_layout_draw();
+
+    // Title
+    ui_components_main_text_draw(
+        STL_ORANGE,
+        ALIGN_CENTER, VALIGN_TOP,
+        "CONTROLLER PAK RECOVERY\n"
+    );
+
+    if (!state_loaded) {
+        ui_components_main_text_draw(
+            STL_DEFAULT,
+            ALIGN_CENTER, VALIGN_TOP,
+            "\n\n\n"
+            "Loading state information...\n"
+        );
+    } else {
+        // Show dirty state info
+        ui_components_main_text_draw(
+            STL_DEFAULT,
+            ALIGN_LEFT, VALIGN_TOP,
+            "\n\n"
+            "The menu did not exit cleanly after playing:\n"
+        );
+
+        time_t ts = (time_t)dirty_state.timestamp;
+        struct tm tm = *localtime(&ts);
+
+        ui_components_main_text_draw(
+            STL_GREEN,
+            ALIGN_LEFT, VALIGN_TOP,
+            "\n\n\n\n"
+            "  Game: %.20s\n"
+            "  Code: %.4s\n"
+            "  Time: %04d-%02d-%02d %02d:%02d:%02d\n",
+            dirty_state.game_title,
+            dirty_state.game_code,
+            tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+            tm.tm_hour, tm.tm_min, tm.tm_sec
+        );
+
+        ui_components_main_text_draw(
+            STL_DEFAULT,
+            ALIGN_LEFT, VALIGN_TOP,
+            "\n\n\n\n\n\n\n\n"
+            "Pak file: %.40s\n",
+            dirty_state.pak_path
+        );
+
+        if (no_physical_pak) {
+            ui_components_main_text_draw(
+                STL_ORANGE,
+                ALIGN_CENTER, VALIGN_TOP,
+                "\n\n\n\n\n\n\n\n\n\n\n"
+                "Warning: No Controller Pak detected in Port 1.\n"
+                "Insert the pak that was used, then press A.\n"
+            );
+        } else {
+            ui_components_main_text_draw(
+                STL_DEFAULT,
+                ALIGN_CENTER, VALIGN_TOP,
+                "\n\n\n\n\n\n\n\n\n\n\n"
+                "Would you like to save the current\n"
+                "Controller Pak contents to this file?\n"
+            );
+        }
+    }
+
+    // Actions bar
+    ui_components_actions_bar_text_draw(
+        STL_DEFAULT,
+        ALIGN_LEFT, VALIGN_TOP,
+        "A: Update Pak Now\n"
+        "B: Discard Changes\n"
+    );
+
+    // Dialogs
+    if (show_backing_up) {
+        ui_components_messagebox_draw(
+            "Backing up Controller Pak...\n\n"
+            "Please wait..."
+        );
+    } else if (show_backup_result) {
+        if (backup_success) {
+            ui_components_messagebox_draw(
+                "Controller Pak backed up successfully!\n\n"
+                "Press A to continue."
+            );
+        } else {
+            if (no_physical_pak) {
+                ui_components_messagebox_draw(
+                    "Backup failed!\n\n"
+                    "No Controller Pak detected.\n"
+                    "Insert pak and try again, or press B to discard.\n\n"
+                    "Press A to continue without backup."
+                );
+            } else {
+                ui_components_messagebox_draw(
+                    "Backup failed!\n\n"
+                    "An error occurred while backing up.\n\n"
+                    "Press A to continue without backup."
+                );
+            }
+        }
+    }
+
+    rdpq_detach_show();
+}
+
+
+void view_vcpak_recovery_init(menu_t *menu) {
+    state_loaded = false;
+    backup_pending = false;
+    show_backing_up = false;
+    show_backup_result = false;
+    backup_success = false;
+    no_physical_pak = false;
+
+    // Load the dirty state
+    vcpak_err_t err = vcpak_state_load(menu->storage_prefix, &dirty_state);
+    if (err == VCPAK_OK) {
+        state_loaded = true;
+    } else {
+        // No dirty state found, shouldn't be here
+        // Just proceed to startup
+        menu->next_mode = MENU_MODE_STARTUP;
+        return;
+    }
+
+    // Check for physical pak
+    if (!has_cpak(0)) {
+        no_physical_pak = true;
+    }
+}
+
+void view_vcpak_recovery_display(menu_t *menu, surface_t *display) {
+    process(menu);
+    draw(menu, display);
+}

--- a/src/menu/views/vcpak_select.c
+++ b/src/menu/views/vcpak_select.c
@@ -1,0 +1,404 @@
+/**
+ * @file vcpak_select.c
+ * @brief Virtual Controller Pak selection view.
+ * @ingroup view
+ *
+ * This view allows users to select which virtual Controller Pak to use
+ * when launching a game that supports Controller Pak saves.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <libdragon.h>
+
+#include "views.h"
+#include "../sound.h"
+#include "../fonts.h"
+#include "../path.h"
+#include "../virtual_cpak.h"
+#include "../rom_info.h"
+#include "utils/cpakfs_utils.h"
+
+
+#define MAX_VISIBLE_ENTRIES 10
+#define CREATE_NEW_INDEX    -1
+
+
+static vcpak_list_t pak_list;  // pak_list.selected: -1 = "Create New", 0+ = pak entry index
+static int scroll_offset;
+static bool show_no_cpak_warning;
+static bool show_delete_confirm;
+static bool show_create_error;
+static char create_error_message[128];
+static char new_pak_filename[64];
+static char new_pak_full_path[256];
+
+
+static void reset_state(void) {
+    scroll_offset = 0;
+    show_no_cpak_warning = false;
+    show_delete_confirm = false;
+    show_create_error = false;
+    create_error_message[0] = '\0';
+    new_pak_filename[0] = '\0';
+    new_pak_full_path[0] = '\0';
+}
+
+static void move_selection(int delta) {
+    // Range: -1 (Create New) to pak_list.count-1
+    int new_sel = pak_list.selected + delta;
+
+    if (new_sel < CREATE_NEW_INDEX) {
+        new_sel = pak_list.count - 1;  // Wrap to bottom
+    } else if (new_sel >= pak_list.count) {
+        new_sel = CREATE_NEW_INDEX;  // Wrap to top
+    }
+
+    pak_list.selected = new_sel;
+
+    // Adjust scroll offset to keep selection visible
+    // Account for "Create New" taking position 0 in display
+    int display_pos = new_sel + 1;  // +1 because Create New is at 0
+    if (display_pos < scroll_offset) {
+        scroll_offset = display_pos;
+    } else if (display_pos >= scroll_offset + MAX_VISIBLE_ENTRIES) {
+        scroll_offset = display_pos - MAX_VISIBLE_ENTRIES + 1;
+    }
+}
+
+static void process(menu_t *menu) {
+    // Handle warning dialog
+    if (show_no_cpak_warning) {
+        if (menu->actions.enter || menu->actions.back) {
+            sound_play_effect(SFX_ENTER);
+            show_no_cpak_warning = false;
+        }
+        return;
+    }
+
+    // Handle create error dialog
+    if (show_create_error) {
+        if (menu->actions.enter || menu->actions.back) {
+            sound_play_effect(SFX_EXIT);
+            show_create_error = false;
+        }
+        return;
+    }
+
+    // Handle delete confirmation
+    if (show_delete_confirm) {
+        if (menu->actions.enter) {
+            sound_play_effect(SFX_ENTER);
+            // Delete the selected pak file
+            int sel = pak_list.selected;
+            if (sel >= 0 && sel < pak_list.count) {
+                remove(pak_list.entries[sel].full_path);
+                // Reload the list
+                vcpak_list_free(&pak_list);
+                vcpak_list_paks(menu->storage_prefix,
+                               menu->load.rom_info.game_code,
+                               menu->load.rom_info.settings.last_cpak_file,
+                               &pak_list);
+            }
+            show_delete_confirm = false;
+        } else if (menu->actions.back) {
+            sound_play_effect(SFX_EXIT);
+            show_delete_confirm = false;
+        }
+        return;
+    }
+
+    // Normal navigation
+    if (menu->actions.go_up) {
+        sound_play_effect(SFX_CURSOR);
+        move_selection(-1);
+    } else if (menu->actions.go_down) {
+        sound_play_effect(SFX_CURSOR);
+        move_selection(1);
+    } else if (menu->actions.back) {
+        sound_play_effect(SFX_EXIT);
+        vcpak_list_free(&pak_list);
+        menu->next_mode = MENU_MODE_LOAD_ROM;
+    } else if (menu->actions.enter) {
+        sound_play_effect(SFX_ENTER);
+
+        int sel = pak_list.selected;
+
+        if (sel == CREATE_NEW_INDEX) {
+            // Create new pak
+            // Generate filename
+            vcpak_generate_filename(menu->storage_prefix,
+                                   menu->load.rom_info.game_code,
+                                   menu->load.rom_info.title,
+                                   new_pak_filename,
+                                   sizeof(new_pak_filename));
+
+            // Build full path
+            char game_dir[256];
+            vcpak_get_game_directory(menu->storage_prefix,
+                                     menu->load.rom_info.game_code,
+                                     game_dir, sizeof(game_dir));
+            path_t *full_path = path_create(game_dir);
+            path_push(full_path, new_pak_filename);
+            strncpy(new_pak_full_path, path_get(full_path), sizeof(new_pak_full_path) - 1);
+            new_pak_full_path[sizeof(new_pak_full_path) - 1] = '\0';
+            path_free(full_path);
+
+            // Ensure directory exists
+            vcpak_err_t dir_err = vcpak_ensure_game_directory(menu->storage_prefix,
+                                        menu->load.rom_info.game_code);
+            if (dir_err != VCPAK_OK) {
+                show_create_error = true;
+                snprintf(create_error_message, sizeof(create_error_message),
+                         "Failed to create pak directory.\nError code: %d", dir_err);
+                return;
+            }
+
+            // Create empty pak file
+            vcpak_err_t create_err = vcpak_create_empty(new_pak_full_path);
+            if (create_err != VCPAK_OK) {
+                show_create_error = true;
+                snprintf(create_error_message, sizeof(create_error_message),
+                         "Failed to create pak file.\nError: %d", create_err);
+                return;
+            }
+
+            // Set up load state
+            menu->load.vcpak_enabled = true;
+            strncpy(menu->load.vcpak_selected, new_pak_full_path,
+                    sizeof(menu->load.vcpak_selected) - 1);
+            menu->load.vcpak_selected[sizeof(menu->load.vcpak_selected) - 1] = '\0';
+
+            // Save as last used
+            rom_config_setting_set_last_cpak(menu->load.rom_path,
+                                             &menu->load.rom_info,
+                                             new_pak_filename);
+
+            vcpak_list_free(&pak_list);
+            menu->load_pending.rom_file = true;
+            menu->next_mode = MENU_MODE_LOAD_ROM;
+        } else if (sel >= 0 && sel < pak_list.count) {
+            // Selected existing pak
+            menu->load.vcpak_enabled = true;
+            strncpy(menu->load.vcpak_selected,
+                    pak_list.entries[sel].full_path,
+                    sizeof(menu->load.vcpak_selected) - 1);
+
+            // Save as last used
+            rom_config_setting_set_last_cpak(menu->load.rom_path,
+                                             &menu->load.rom_info,
+                                             pak_list.entries[sel].filename);
+
+            vcpak_list_free(&pak_list);
+            menu->load_pending.rom_file = true;
+            menu->next_mode = MENU_MODE_LOAD_ROM;
+        }
+    } else if (menu->actions.options) {
+        // R button: Delete selected pak (if not "Create New")
+        int sel = pak_list.selected;
+        if (sel >= 0 && sel < pak_list.count) {
+            sound_play_effect(SFX_SETTING);
+            show_delete_confirm = true;
+        }
+    }
+}
+
+static void draw(menu_t *menu, surface_t *d) {
+    rdpq_attach(d, NULL);
+
+    ui_components_background_draw();
+    ui_components_layout_draw();
+
+    // Title
+    ui_components_main_text_draw(
+        STL_DEFAULT,
+        ALIGN_CENTER, VALIGN_TOP,
+        "SELECT CONTROLLER PAK\n"
+    );
+
+    // Game info
+    ui_components_main_text_draw(
+        STL_GREEN,
+        ALIGN_CENTER, VALIGN_TOP,
+        "\n"
+        "%.20s (%.4s)\n",
+        menu->load.rom_info.title,
+        menu->load.rom_info.game_code
+    );
+
+    // Draw pak list
+    int y_offset = 4;  // Starting line for list
+
+    // "Create New Pak" option - only show if not scrolled past
+    if (scroll_offset == 0) {
+        menu_font_type_t style = (pak_list.selected == CREATE_NEW_INDEX) ? STL_GREEN : STL_DEFAULT;
+        char prefix = (pak_list.selected == CREATE_NEW_INDEX) ? '>' : ' ';
+
+        ui_components_main_text_draw(
+            style,
+            ALIGN_LEFT, VALIGN_TOP,
+            "\n\n\n\n"
+            "%c [Create New Controller Pak]\n",
+            prefix
+        );
+        y_offset++;
+    }
+
+    // Existing pak entries
+    // When scroll_offset == 0: show paks 0 to MAX_VISIBLE_ENTRIES-2 (Create New takes one slot)
+    // When scroll_offset > 0: show paks (scroll_offset-1) to (scroll_offset-1+MAX_VISIBLE_ENTRIES-1)
+    int first_pak = (scroll_offset == 0) ? 0 : scroll_offset - 1;
+    int max_visible_paks = (scroll_offset == 0) ? MAX_VISIBLE_ENTRIES - 1 : MAX_VISIBLE_ENTRIES;
+
+    for (int i = 0; i < max_visible_paks; i++) {
+        int entry_idx = first_pak + i;
+        if (entry_idx >= pak_list.count) break;
+
+        vcpak_entry_t *entry = &pak_list.entries[entry_idx];
+        menu_font_type_t style = (pak_list.selected == entry_idx) ? STL_GREEN : STL_DEFAULT;
+        char prefix = (pak_list.selected == entry_idx) ? '>' : ' ';
+        const char *marker = entry->is_last_used ? " *" : "";
+
+        // Build line number string for vertical positioning
+        int num_newlines = y_offset + i + 4;
+        char newlines[32];
+        if (num_newlines > (int)(sizeof(newlines) - 1)) {
+            num_newlines = sizeof(newlines) - 1;
+        }
+        memset(newlines, '\n', num_newlines);
+        newlines[num_newlines] = '\0';
+
+        ui_components_main_text_draw(
+            style,
+            ALIGN_LEFT, VALIGN_TOP,
+            "%s%c %.50s%s\n",
+            newlines,
+            prefix,
+            entry->filename,
+            marker
+        );
+    }
+
+    // Show count info
+    if (pak_list.count > 0) {
+        ui_components_main_text_draw(
+            STL_GRAY,
+            ALIGN_RIGHT, VALIGN_TOP,
+            "\n\n\n"
+            "%d pak(s) available\n",
+            pak_list.count
+        );
+    }
+
+    // No physical pak warning indicator
+    if (menu->load.vcpak_no_physical) {
+        ui_components_main_text_draw(
+            STL_ORANGE,
+            ALIGN_CENTER, VALIGN_TOP,
+            "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
+            "Warning: No Controller Pak in Port 1\n"
+        );
+    }
+
+    // Actions bar
+    ui_components_actions_bar_text_draw(
+        STL_DEFAULT,
+        ALIGN_LEFT, VALIGN_TOP,
+        "A: Select\n"
+        "B: Cancel\n"
+    );
+
+    if (pak_list.selected >= 0 && pak_list.selected < pak_list.count) {
+        ui_components_actions_bar_text_draw(
+            STL_DEFAULT,
+            ALIGN_RIGHT, VALIGN_TOP,
+            "R: Delete Pak\n"
+            "* = Last Used\n"
+        );
+    } else {
+        ui_components_actions_bar_text_draw(
+            STL_DEFAULT,
+            ALIGN_RIGHT, VALIGN_TOP,
+            "\n"
+            "* = Last Used\n"
+        );
+    }
+
+    // Dialogs
+    if (show_no_cpak_warning) {
+        ui_components_messagebox_draw(
+            "No Controller Pak detected in Port 1.\n\n"
+            "The game will launch but Controller Pak\n"
+            "saves will not work.\n\n"
+            "Press A or B to continue."
+        );
+    }
+
+    if (show_delete_confirm) {
+        int sel = pak_list.selected;
+        if (sel >= 0 && sel < pak_list.count) {
+            ui_components_messagebox_draw(
+                "Delete this Controller Pak file?\n\n"
+                "%.50s\n\n"
+                "A: Delete    B: Cancel",
+                pak_list.entries[sel].filename
+            );
+        }
+    }
+
+    if (show_create_error) {
+        ui_components_messagebox_draw(
+            "ERROR: Could not create pak\n\n"
+            "%s\n\n"
+            "Press A or B to continue.",
+            create_error_message
+        );
+    }
+
+    rdpq_detach_show();
+}
+
+
+void view_vcpak_select_init(menu_t *menu) {
+    reset_state();
+
+    // Initialize vcpak load state
+    menu->load.vcpak_enabled = false;
+    menu->load.vcpak_selected[0] = '\0';
+    menu->load.vcpak_no_physical = false;
+
+    // Check for physical pak
+    if (!has_cpak(0)) {
+        menu->load.vcpak_no_physical = true;
+        show_no_cpak_warning = true;
+    }
+
+    // Ensure game directory exists
+    vcpak_ensure_game_directory(menu->storage_prefix,
+                                 menu->load.rom_info.game_code);
+
+    // Load list of available paks for this game
+    vcpak_list_paks(menu->storage_prefix,
+                    menu->load.rom_info.game_code,
+                    menu->load.rom_info.settings.last_cpak_file,
+                    &pak_list);
+
+    // If no paks exist, default to "Create New"
+    if (pak_list.count == 0) {
+        pak_list.selected = CREATE_NEW_INDEX;
+    }
+
+    // Initialize scroll_offset so selected item is visible
+    if (pak_list.selected >= 0) {
+        int display_pos = pak_list.selected + 1;
+        if (display_pos >= MAX_VISIBLE_ENTRIES) {
+            scroll_offset = display_pos - MAX_VISIBLE_ENTRIES + 1;
+        }
+    }
+}
+
+void view_vcpak_select_display(menu_t *menu, surface_t *display) {
+    process(menu);
+    draw(menu, display);
+}

--- a/src/menu/views/views.h
+++ b/src/menu/views/views.h
@@ -355,6 +355,32 @@ void view_extract_file_init(menu_t *menu);
 void view_extract_file_display(menu_t *menu, surface_t *display);
 
 /**
+ * @brief Initialize the virtual Controller Pak selection view.
+ * @param menu Pointer to the menu structure.
+ */
+void view_vcpak_select_init(menu_t *menu);
+
+/**
+ * @brief Display the virtual Controller Pak selection view.
+ * @param menu Pointer to the menu structure.
+ * @param display Pointer to the display surface.
+ */
+void view_vcpak_select_display(menu_t *menu, surface_t *display);
+
+/**
+ * @brief Initialize the virtual Controller Pak recovery view.
+ * @param menu Pointer to the menu structure.
+ */
+void view_vcpak_recovery_init(menu_t *menu);
+
+/**
+ * @brief Display the virtual Controller Pak recovery view.
+ * @param menu Pointer to the menu structure.
+ * @param display Pointer to the display surface.
+ */
+void view_vcpak_recovery_display(menu_t *menu, surface_t *display);
+
+/**
  * @brief Show an error message in the menu.
  *
  * @param menu Pointer to the menu structure.

--- a/src/menu/virtual_cpak.c
+++ b/src/menu/virtual_cpak.c
@@ -1,0 +1,638 @@
+/**
+ * @file virtual_cpak.c
+ * @brief Implementation of Virtual Controller Pak management.
+ * @ingroup menu
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+#include <libdragon.h>
+#include <dir.h>
+
+#include "virtual_cpak.h"
+#include "path.h"
+#include "utils/fs.h"
+#include "utils/cpakfs_utils.h"
+
+/* Debug logging prefix for all vcpak operations */
+#define VCPAK_DEBUG_PREFIX "vcpak: "
+
+/* Maximum numbered pak files per game before falling back to timestamp naming */
+#define VCPAK_MAX_PAK_NUMBER 999
+
+/*
+ * Directory Management
+ */
+
+void vcpak_get_game_directory(const char *storage_prefix, const char *game_code,
+                               char *out_path, size_t out_size) {
+    // Game code is only 4 bytes in ROM header, not null-terminated
+    // Make a safe copy
+    char safe_code[5];
+    memcpy(safe_code, game_code, 4);
+    safe_code[4] = '\0';
+
+    path_t *path = path_init(storage_prefix, VCPAK_SAVES_BASE_DIR);
+    path_push(path, safe_code);
+
+    strncpy(out_path, path_get(path), out_size - 1);
+    out_path[out_size - 1] = '\0';
+
+    path_free(path);
+}
+
+vcpak_err_t vcpak_ensure_game_directory(const char *storage_prefix, const char *game_code) {
+    char safe_code[5];
+    memcpy(safe_code, game_code, 4);
+    safe_code[4] = '\0';
+
+    // Create base directory first
+    path_t *base_path = path_init(storage_prefix, VCPAK_SAVES_BASE_DIR);
+
+    if (!directory_exists(path_get(base_path))) {
+        if (directory_create(path_get(base_path))) {
+            path_free(base_path);
+            return VCPAK_ERR_DIR_CREATE;
+        }
+    }
+
+    // Create game-specific directory
+    path_push(base_path, safe_code);
+
+    if (!directory_exists(path_get(base_path))) {
+        if (directory_create(path_get(base_path))) {
+            path_free(base_path);
+            return VCPAK_ERR_DIR_CREATE;
+        }
+    }
+
+    path_free(base_path);
+    return VCPAK_OK;
+}
+
+
+/*
+ * Pak File Enumeration
+ */
+
+vcpak_err_t vcpak_list_paks(const char *storage_prefix, const char *game_code,
+                            const char *last_used_filename, vcpak_list_t *out_list) {
+    char safe_code[5];
+    memcpy(safe_code, game_code, 4);
+    safe_code[4] = '\0';
+
+    dir_t dir_entry;
+    int count = 0;
+    int capacity = 16;
+
+    // Initialize output
+    memset(out_list, 0, sizeof(*out_list));
+    strncpy(out_list->game_code, game_code, sizeof(out_list->game_code) - 1);
+    out_list->selected = -1;
+
+    path_t *game_dir = path_init(storage_prefix, VCPAK_SAVES_BASE_DIR);
+    path_push(game_dir, safe_code);
+
+    // Allocate initial array
+    out_list->entries = malloc(capacity * sizeof(vcpak_entry_t));
+    if (!out_list->entries) {
+        path_free(game_dir);
+        return VCPAK_ERR_ALLOC;
+    }
+
+    // Check if directory exists
+    if (!directory_exists(path_get(game_dir))) {
+        out_list->count = 0;
+        path_free(game_dir);
+        return VCPAK_OK;
+    }
+
+    // Enumerate .pak files
+    if (dir_findfirst(path_get(game_dir), &dir_entry) >= 0) {
+        do {
+            // Check for .pak extension
+            char *ext = strrchr(dir_entry.d_name, '.');
+            if (!ext || strcasecmp(ext, ".pak") != 0) {
+                continue;
+            }
+
+            // Expand array if needed
+            if (count >= capacity) {
+                capacity *= 2;
+                vcpak_entry_t *new_entries = realloc(out_list->entries,
+                                                      capacity * sizeof(vcpak_entry_t));
+                if (!new_entries) {
+                    free(out_list->entries);
+                    out_list->entries = NULL;
+                    path_free(game_dir);
+                    return VCPAK_ERR_ALLOC;
+                }
+                out_list->entries = new_entries;
+            }
+
+            // Populate entry
+            vcpak_entry_t *entry = &out_list->entries[count];
+            strncpy(entry->filename, dir_entry.d_name, sizeof(entry->filename) - 1);
+            entry->filename[sizeof(entry->filename) - 1] = '\0';
+
+            path_t *full_path = path_clone_push(game_dir, dir_entry.d_name);
+            strncpy(entry->full_path, path_get(full_path), sizeof(entry->full_path) - 1);
+            entry->full_path[sizeof(entry->full_path) - 1] = '\0';
+            path_free(full_path);
+
+            // Check if this is the last-used pak
+            entry->is_last_used = false;
+            if (last_used_filename && last_used_filename[0] != '\0') {
+                if (strcmp(entry->filename, last_used_filename) == 0) {
+                    entry->is_last_used = true;
+                    out_list->selected = count;
+                }
+            }
+
+            count++;
+        } while (dir_findnext(path_get(game_dir), &dir_entry) == 0);
+    }
+
+    path_free(game_dir);
+    out_list->count = count;
+
+    // If no last-used was found but we have entries, select the first one
+    if (out_list->selected < 0 && count > 0) {
+        out_list->selected = 0;
+    }
+
+    return VCPAK_OK;
+}
+
+void vcpak_list_free(vcpak_list_t *list) {
+    if (list->entries) {
+        free(list->entries);
+        list->entries = NULL;
+    }
+    list->count = 0;
+    list->selected = -1;
+}
+
+
+/*
+ * Pak Operations
+ */
+
+vcpak_err_t vcpak_restore_to_physical(const char *pak_path, int controller) {
+    debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: path=%s, controller=%d\n", pak_path, controller);
+
+    if (!has_cpak(controller)) {
+        debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: no cpak in port %d\n", controller);
+        return VCPAK_ERR_NO_CPAK;
+    }
+
+    /* Unmount any existing filesystem on the pak */
+    cpakfs_unmount(controller);
+
+    uint8_t *data = malloc(CPAK_BANK_SIZE);
+    if (!data) {
+        debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: malloc failed\n");
+        return VCPAK_ERR_ALLOC;
+    }
+
+    FILE *fp = fopen(pak_path, "rb");
+    if (!fp) {
+        debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: file not found: %s\n", pak_path);
+        free(data);
+        return VCPAK_ERR_FILE_NOT_FOUND;
+    }
+
+    /* Get file size */
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: fseek failed\n");
+        fclose(fp);
+        free(data);
+        return VCPAK_ERR_IO;
+    }
+    long filesize = ftell(fp);
+    if (filesize < 0) {
+        debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: ftell failed\n");
+        fclose(fp);
+        free(data);
+        return VCPAK_ERR_IO;
+    }
+    rewind(fp);
+
+    int total_banks = (int)((filesize + CPAK_BANK_SIZE - 1) / CPAK_BANK_SIZE);
+    debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: filesize=%ld, banks=%d\n", filesize, total_banks);
+
+    /* Check if file fits on physical pak */
+    int banks_on_device = cpak_probe_banks(controller);
+    if (banks_on_device < 1) {
+        debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: cpak_probe_banks failed\n");
+        fclose(fp);
+        free(data);
+        return VCPAK_ERR_CORRUPTED;
+    }
+    if (total_banks > banks_on_device) {
+        debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: file too large (%d banks > %d on device)\n",
+               total_banks, banks_on_device);
+        fclose(fp);
+        free(data);
+        return VCPAK_ERR_TOO_LARGE;
+    }
+
+    /* Write banks to physical pak */
+    for (int bank = 0; bank < total_banks; bank++) {
+        size_t bytes_read = fread(data, 1, CPAK_BANK_SIZE, fp);
+        if (bytes_read == 0 && ferror(fp)) {
+            debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: fread error at bank %d\n", bank);
+            fclose(fp);
+            free(data);
+            return VCPAK_ERR_IO;
+        }
+        if (bytes_read == 0 && feof(fp)) {
+            break;
+        }
+
+        int written = cpak_write((joypad_port_t)controller, (uint8_t)bank, 0, data, bytes_read);
+        if (written < 0 || (size_t)written != bytes_read) {
+            debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: cpak_write failed at bank %d (wrote %d)\n",
+                   bank, written);
+            fclose(fp);
+            free(data);
+            return VCPAK_ERR_IO;
+        }
+    }
+
+    fclose(fp);
+    free(data);
+    debugf(VCPAK_DEBUG_PREFIX "restore_to_physical: success\n");
+    return VCPAK_OK;
+}
+
+vcpak_err_t vcpak_backup_from_physical(const char *pak_path, int controller) {
+    debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: path=%s, controller=%d\n", pak_path, controller);
+
+    if (!has_cpak(controller)) {
+        debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: no cpak in port %d\n", controller);
+        return VCPAK_ERR_NO_CPAK;
+    }
+
+    int banks = cpak_probe_banks(controller);
+    if (banks < 1) {
+        debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: cpak_probe_banks returned %d, using 1\n", banks);
+        banks = 1;  /* Fallback to 1 bank */
+    }
+    debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: %d banks to backup\n", banks);
+
+    uint8_t *data = malloc(CPAK_BANK_SIZE);
+    if (!data) {
+        debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: malloc failed\n");
+        return VCPAK_ERR_ALLOC;
+    }
+
+    FILE *fp = fopen(pak_path, "wb");
+    if (!fp) {
+        debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: fopen failed for %s\n", pak_path);
+        free(data);
+        return VCPAK_ERR_IO;
+    }
+
+    /* Read banks from physical pak and write to file */
+    for (int bank = 0; bank < banks; bank++) {
+        int bytes_read = cpak_read((joypad_port_t)controller, (uint8_t)bank, 0,
+                                    data, CPAK_BANK_SIZE);
+        if (bytes_read < 0 || bytes_read != CPAK_BANK_SIZE) {
+            debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: cpak_read failed at bank %d (read %d)\n",
+                   bank, bytes_read);
+            fclose(fp);
+            free(data);
+            return VCPAK_ERR_IO;
+        }
+
+        size_t written = fwrite(data, 1, CPAK_BANK_SIZE, fp);
+        if (written != CPAK_BANK_SIZE) {
+            debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: fwrite failed at bank %d\n", bank);
+            fclose(fp);
+            free(data);
+            return VCPAK_ERR_IO;
+        }
+    }
+
+    fclose(fp);
+    free(data);
+    debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: success\n");
+    return VCPAK_OK;
+}
+
+/**
+ * @brief Calculate the ID sector checksum (matches libdragon's __cpakfs_fsid_checksum)
+ *
+ * The checksum is computed over the first 14 big-endian words (28 bytes) of the ID sector.
+ */
+static void vcpak_calc_id_checksum(const uint8_t *id_sector, uint16_t *checksum1, uint16_t *checksum2) {
+    uint32_t sum = 0;
+    for (int i = 0; i < 14; i++) {
+        // Read as big-endian 16-bit value
+        sum += ((uint16_t)id_sector[i * 2] << 8) | id_sector[i * 2 + 1];
+    }
+    *checksum1 = sum & 0xFFFF;
+    *checksum2 = 0xFFF2 - *checksum1;
+}
+
+/**
+ * @brief Calculate the FAT page checksum (matches libdragon's __cpakfs_fat_checksum)
+ *
+ * The checksum is the sum of all bytes in entries starting from start_idx.
+ */
+static uint8_t vcpak_calc_fat_checksum(const uint8_t *fat_page, int start_idx) {
+    uint8_t checksum = 0;
+    for (int i = start_idx; i < 128; i++) {
+        checksum += fat_page[i * 2];      // bank byte
+        checksum += fat_page[i * 2 + 1];  // page byte
+    }
+    return checksum;
+}
+
+vcpak_err_t vcpak_create_empty(const char *pak_path) {
+    debugf(VCPAK_DEBUG_PREFIX "create_empty: path=%s\n", pak_path);
+
+    // Create a properly formatted empty Controller Pak image
+    // Standard pak is 32KB (1 bank) with proper filesystem structure
+    //
+    // Structure (32KB = 128 pages of 256 bytes):
+    // - Page 0 (0x000-0x0FF): ID area with checksums at specific blocks
+    // - Pages 1-2 (0x100-0x2FF): FAT (File Allocation Table) and backup
+    // - Pages 3-4 (0x300-0x4FF): Note table and backup
+    // - Pages 5-127 (0x500-0x7FFF): Data pages (available for saves)
+
+    uint8_t *data = malloc(CPAK_BANK_SIZE);
+    if (!data) {
+        debugf(VCPAK_DEBUG_PREFIX "create_empty: malloc failed\n");
+        return VCPAK_ERR_ALLOC;
+    }
+
+    // Initialize entire pak with 0x00
+    memset(data, 0x00, CPAK_BANK_SIZE);
+
+    // === PAGE 0: ID Area ===
+    // The ID sector (32 bytes) is written at 4 locations within page 0:
+    // blocks 1, 3, 4, 6 (offsets 0x20, 0x60, 0x80, 0xC0)
+    // This matches libdragon's pattern: 0x5A = 01011010 binary
+
+    // Build the ID sector (32 bytes)
+    uint8_t id_sector[32];
+    memset(id_sector, 0, 32);
+
+    // Bytes 0-23: Serial number (can be zeros or random, we use a simple pattern)
+    // Using "N64MENU" as identifier in the serial area
+    memcpy(&id_sector[0], "N64MENUVPAK", 11);
+    // Rest of serial is zeros
+
+    // Bytes 24-25: device_id_lsb (big-endian, value 0x0001)
+    id_sector[24] = 0x00;
+    id_sector[25] = 0x01;
+
+    // Bytes 26-27: bank_size_msb (big-endian, value 0x0100 for 1 bank = 256 FAT entries)
+    id_sector[26] = 0x01;
+    id_sector[27] = 0x00;
+
+    // Bytes 28-31: checksums (calculated below)
+    uint16_t checksum1, checksum2;
+    vcpak_calc_id_checksum(id_sector, &checksum1, &checksum2);
+
+    // Store checksums in big-endian
+    id_sector[28] = (checksum1 >> 8) & 0xFF;
+    id_sector[29] = checksum1 & 0xFF;
+    id_sector[30] = (checksum2 >> 8) & 0xFF;
+    id_sector[31] = checksum2 & 0xFF;
+
+    // Write ID sector to all 4 required locations (pattern 0x5A)
+    // Bit positions: 1, 3, 4, 6 -> offsets 0x20, 0x60, 0x80, 0xC0
+    memcpy(&data[0x20], id_sector, 32);
+    memcpy(&data[0x60], id_sector, 32);
+    memcpy(&data[0x80], id_sector, 32);
+    memcpy(&data[0xC0], id_sector, 32);
+
+    // === PAGES 1-2: FAT (File Allocation Table) ===
+    // For a 1-bank pak, the reserved pages are:
+    // Page 0: ID sector
+    // Pages 1-2: FAT (2 copies)
+    // Pages 3-4: Note table (2 copies)
+    // Total reserved: 5 pages (indices 0-4)
+    //
+    // FAT entry format: 2 bytes (bank, page)
+    // - 0x00, 0x00 = Reserved (system page)
+    // - 0x00, 0x01 = End of chain (terminator)
+    // - 0x00, 0x03 = Unused (free page)
+
+    uint8_t fat_page[256];
+    memset(fat_page, 0, 256);
+
+    // Entry 0: will hold checksum (set after calculating)
+    fat_page[0] = 0x00;
+    fat_page[1] = 0x00;  // placeholder for checksum
+
+    // Entries 1-4: Reserved (system pages)
+    for (int i = 1; i <= 4; i++) {
+        fat_page[i * 2] = 0x00;      // bank = 0
+        fat_page[i * 2 + 1] = 0x00;  // page = 0 (reserved marker)
+    }
+
+    // Entries 5-127: Unused (free pages available for saves)
+    for (int i = 5; i < 128; i++) {
+        fat_page[i * 2] = 0x00;      // bank = 0
+        fat_page[i * 2 + 1] = 0x03;  // page = 3 (unused marker)
+    }
+
+    // Calculate and store FAT checksum
+    // For the first FAT page, checksum starts from index 5 (after reserved entries)
+    // Actually, libdragon uses: int reserved = 1 + (fat_size >> 8) * 2 + 2 = 5
+    // And checksum is calculated from index 1 for simplicity (matching __cpakfs_fat_checksum behavior)
+    uint8_t fat_checksum = vcpak_calc_fat_checksum(fat_page, 5);
+    fat_page[1] = fat_checksum;
+
+    // Write FAT to page 1 (0x100) and backup to page 2 (0x200)
+    memcpy(&data[0x100], fat_page, 256);
+    memcpy(&data[0x200], fat_page, 256);
+
+    // === PAGES 3-4: Note Table ===
+    // The note table holds 16 notes of 32 bytes each = 512 bytes total
+    // For an empty pak, all notes are zeroed (empty)
+    // Pages 3-4 (0x300-0x4FF) are already zeroed from memset
+
+    // === PAGES 5-127: Data Pages ===
+    // Already zeroed from memset, available for game saves
+
+    FILE *fp = fopen(pak_path, "wb");
+    if (!fp) {
+        debugf(VCPAK_DEBUG_PREFIX "create_empty: fopen failed for %s\n", pak_path);
+        free(data);
+        return VCPAK_ERR_IO;
+    }
+
+    size_t written = fwrite(data, 1, CPAK_BANK_SIZE, fp);
+    fclose(fp);
+    free(data);
+
+    if (written != CPAK_BANK_SIZE) {
+        debugf(VCPAK_DEBUG_PREFIX "create_empty: fwrite failed (wrote %zu)\n", written);
+        return VCPAK_ERR_IO;
+    }
+
+    debugf(VCPAK_DEBUG_PREFIX "create_empty: success\n");
+    return VCPAK_OK;
+}
+
+vcpak_err_t vcpak_generate_filename(const char *storage_prefix, const char *game_code,
+                                    const char *game_title, char *out_filename, size_t out_size) {
+    char safe_code[5];
+    memcpy(safe_code, game_code, 4);
+    safe_code[4] = '\0';
+
+    char clean_title[32];
+
+    path_t *game_dir = path_init(storage_prefix, VCPAK_SAVES_BASE_DIR);
+    path_push(game_dir, safe_code);
+
+    // Clean up the game title for use in filename
+    // Remove spaces and special characters
+    // Note: ROM titles are fixed 20-byte fields, not always null-terminated
+    int j = 0;
+    for (int i = 0; i < 20 && game_title[i] != '\0' && j < 20; i++) {
+        char c = game_title[i];
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+            (c >= '0' && c <= '9')) {
+            clean_title[j++] = c;
+        }
+    }
+    clean_title[j] = '\0';
+
+    // If title is empty, use game code
+    if (clean_title[0] == '\0') {
+        strncpy(clean_title, safe_code, sizeof(clean_title) - 1);
+        clean_title[sizeof(clean_title) - 1] = '\0';
+    }
+
+    // Find a unique filename
+    for (int i = 1; i <= VCPAK_MAX_PAK_NUMBER; i++) {
+        snprintf(out_filename, out_size, "%s_%03d.pak", clean_title, i);
+
+        path_t *test_path = path_clone_push(game_dir, out_filename);
+        bool exists = file_exists(path_get(test_path));
+        path_free(test_path);
+
+        if (!exists) {
+            path_free(game_dir);
+            return VCPAK_OK;
+        }
+    }
+
+    path_free(game_dir);
+
+    // Fallback with timestamp if somehow we have 999+ paks
+    time_t now = time(NULL);
+    snprintf(out_filename, out_size, "%s_%ld.pak", clean_title, (long)now);
+    return VCPAK_OK;
+}
+
+
+/*
+ * Dirty State Management
+ */
+
+static void vcpak_get_state_path(const char *storage_prefix, char *out_path, size_t out_size) {
+    path_t *path = path_init(storage_prefix, "menu");
+    path_push(path, VCPAK_STATE_FILENAME);
+
+    strncpy(out_path, path_get(path), out_size - 1);
+    out_path[out_size - 1] = '\0';
+
+    path_free(path);
+}
+
+vcpak_err_t vcpak_state_save(const char *storage_prefix, const vcpak_state_t *state) {
+    char state_path[256];
+    vcpak_get_state_path(storage_prefix, state_path, sizeof(state_path));
+
+    debugf(VCPAK_DEBUG_PREFIX "state_save: path=%s, game=%.4s, dirty=%d\n",
+           state_path, state->game_code, state->is_dirty);
+
+    FILE *fp = fopen(state_path, "wb");
+    if (!fp) {
+        debugf(VCPAK_DEBUG_PREFIX "state_save: fopen failed\n");
+        return VCPAK_ERR_IO;
+    }
+
+    size_t written = fwrite(state, sizeof(*state), 1, fp);
+    fclose(fp);
+
+    if (written != 1) {
+        debugf(VCPAK_DEBUG_PREFIX "state_save: fwrite failed\n");
+        return VCPAK_ERR_IO;
+    }
+
+    debugf(VCPAK_DEBUG_PREFIX "state_save: success\n");
+    return VCPAK_OK;
+}
+
+vcpak_err_t vcpak_state_load(const char *storage_prefix, vcpak_state_t *state) {
+    char state_path[256];
+    vcpak_get_state_path(storage_prefix, state_path, sizeof(state_path));
+
+    if (!file_exists(state_path)) {
+        debugf(VCPAK_DEBUG_PREFIX "state_load: no state file at %s\n", state_path);
+        return VCPAK_ERR_FILE_NOT_FOUND;
+    }
+
+    FILE *fp = fopen(state_path, "rb");
+    if (!fp) {
+        debugf(VCPAK_DEBUG_PREFIX "state_load: fopen failed for %s\n", state_path);
+        return VCPAK_ERR_IO;
+    }
+
+    size_t read_count = fread(state, sizeof(*state), 1, fp);
+    fclose(fp);
+
+    if (read_count != 1) {
+        debugf(VCPAK_DEBUG_PREFIX "state_load: fread failed\n");
+        return VCPAK_ERR_IO;
+    }
+
+    // Validate magic number
+    if (state->magic != VCPAK_STATE_MAGIC) {
+        debugf(VCPAK_DEBUG_PREFIX "state_load: bad magic (got 0x%08lX, expected 0x%08lX)\n",
+               (unsigned long)state->magic, (unsigned long)VCPAK_STATE_MAGIC);
+        return VCPAK_ERR_CORRUPTED;
+    }
+
+    debugf(VCPAK_DEBUG_PREFIX "state_load: success, game=%.4s, dirty=%d\n",
+           state->game_code, state->is_dirty);
+    return VCPAK_OK;
+}
+
+vcpak_err_t vcpak_state_clear(const char *storage_prefix) {
+    char state_path[256];
+    vcpak_get_state_path(storage_prefix, state_path, sizeof(state_path));
+
+    debugf(VCPAK_DEBUG_PREFIX "state_clear: path=%s\n", state_path);
+
+    if (file_exists(state_path)) {
+        if (remove(state_path) != 0) {
+            debugf(VCPAK_DEBUG_PREFIX "state_clear: remove failed\n");
+            return VCPAK_ERR_IO;
+        }
+        debugf(VCPAK_DEBUG_PREFIX "state_clear: file removed\n");
+    }
+
+    return VCPAK_OK;
+}
+
+bool vcpak_state_is_dirty(const char *storage_prefix) {
+    vcpak_state_t state;
+
+    if (vcpak_state_load(storage_prefix, &state) != VCPAK_OK) {
+        return false;
+    }
+
+    return (state.is_dirty != 0);
+}

--- a/src/menu/virtual_cpak.c
+++ b/src/menu/virtual_cpak.c
@@ -237,25 +237,16 @@ vcpak_err_t vcpak_restore_to_physical(const char *pak_path, int controller) {
 vcpak_err_t vcpak_backup_from_physical(const char *pak_path, int controller) {
     debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: path=%s, controller=%d\n", pak_path, controller);
 
-    if (!has_cpak(controller)) {
-        debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: no cpak in port %d\n", controller);
-        return VCPAK_ERR_NO_CPAK;
-    }
-
     cpak_io_context_t ctx;
     cpak_io_err_t err = cpak_backup_to_file(controller, pak_path, &ctx);
 
-    /* Log bank count */
-    if (ctx.device_banks < 1) {
-        debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: cpak_probe_banks returned %d, using 1\n", ctx.device_banks);
-    }
-    int banks_to_backup = (ctx.device_banks < 1) ? 1 : ctx.device_banks;
-    debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: %d banks to backup\n", banks_to_backup);
-
     switch (err) {
         case CPAK_IO_OK:
-            debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: success\n");
+            debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: success (%d banks)\n", ctx.device_banks);
             return VCPAK_OK;
+        case CPAK_IO_ERR_NO_PAK:
+            debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: no cpak in port %d\n", controller);
+            return VCPAK_ERR_NO_CPAK;
         case CPAK_IO_ERR_ALLOC:
             debugf(VCPAK_DEBUG_PREFIX "backup_from_physical: malloc failed\n");
             return VCPAK_ERR_ALLOC;

--- a/src/menu/virtual_cpak.h
+++ b/src/menu/virtual_cpak.h
@@ -1,0 +1,216 @@
+/**
+ * @file virtual_cpak.h
+ * @brief Virtual Controller Pak management for per-game pak saves.
+ * @ingroup menu
+ */
+
+#ifndef VIRTUAL_CPAK_H__
+#define VIRTUAL_CPAK_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/** @brief Base directory for virtual cpak saves on SD card */
+#define VCPAK_SAVES_BASE_DIR    "cpak_saves"
+
+/** @brief Filename for dirty state tracking file */
+#define VCPAK_STATE_FILENAME    "vcpak_state.dat"
+
+/** @brief Magic number for state file validation ("VCPS") */
+#define VCPAK_STATE_MAGIC       0x56435053
+
+/** @brief Virtual CPak error codes */
+typedef enum {
+    VCPAK_OK,                   /**< Success */
+    VCPAK_ERR_NO_CPAK,          /**< No physical Controller Pak detected */
+    VCPAK_ERR_IO,               /**< I/O error during read/write */
+    VCPAK_ERR_CORRUPTED,        /**< Pak data is corrupted */
+    VCPAK_ERR_FILE_NOT_FOUND,   /**< Pak file not found */
+    VCPAK_ERR_ALLOC,            /**< Memory allocation failed */
+    VCPAK_ERR_DIR_CREATE,       /**< Failed to create directory */
+    VCPAK_ERR_TOO_LARGE,        /**< Pak file too large for physical device */
+} vcpak_err_t;
+
+/**
+ * @brief Dirty state information persisted to SD card.
+ *
+ * This structure is written before booting a game and cleared after
+ * successfully backing up the pak on return. If the menu starts and
+ * finds this file with is_dirty=1, an unclean exit occurred.
+ *
+ * Fields are ordered for natural alignment (uint32_t first, then arrays).
+ */
+typedef struct {
+    uint32_t magic;             /**< Magic number for validation (VCPAK_STATE_MAGIC) */
+    uint32_t timestamp;         /**< Unix timestamp when game was launched */
+    char game_code[5];          /**< 4-char game code + null terminator */
+    char game_title[21];        /**< 20-char game title + null terminator */
+    char rom_path[256];         /**< Full path to the ROM file */
+    char pak_path[256];         /**< Full path to the .pak file being used */
+    uint8_t is_dirty;           /**< 1 if session not cleanly ended, 0 otherwise */
+    uint8_t reserved[30];       /**< Reserved for future use */
+} vcpak_state_t;
+
+/**
+ * @brief Entry representing a single pak file in a game's pak list.
+ */
+typedef struct {
+    char filename[64];          /**< Filename only (no path) */
+    char full_path[256];        /**< Full SD card path to the file */
+    bool is_last_used;          /**< True if this was the last used pak for this game */
+} vcpak_entry_t;
+
+/**
+ * @brief List of pak files available for a game.
+ */
+typedef struct {
+    vcpak_entry_t *entries;     /**< Array of pak entries (dynamically allocated) */
+    int count;                  /**< Number of entries in the list */
+    int selected;               /**< Index of currently selected entry (-1 if none) */
+    char game_code[5];          /**< Game code this list is for */
+} vcpak_list_t;
+
+
+/*
+ * Directory Management
+ */
+
+/**
+ * @brief Ensure the game-specific cpak directory exists.
+ *
+ * Creates SD:/cpak_saves/{game_code}/ if it doesn't exist.
+ *
+ * @param storage_prefix The storage prefix (e.g., "sd:/")
+ * @param game_code The 4-character game code
+ * @return vcpak_err_t Error code
+ */
+vcpak_err_t vcpak_ensure_game_directory(const char *storage_prefix, const char *game_code);
+
+/**
+ * @brief Get the full path to a game's cpak directory.
+ *
+ * @param storage_prefix The storage prefix (e.g., "sd:/")
+ * @param game_code The 4-character game code
+ * @param out_path Buffer to store the path (must be at least 256 bytes)
+ * @param out_size Size of the output buffer
+ */
+void vcpak_get_game_directory(const char *storage_prefix, const char *game_code,
+                               char *out_path, size_t out_size);
+
+
+/*
+ * Pak File Enumeration
+ */
+
+/**
+ * @brief List all pak files available for a game.
+ *
+ * Populates the vcpak_list_t structure with entries from the game's
+ * cpak directory. The caller must call vcpak_list_free() when done.
+ *
+ * @param storage_prefix The storage prefix (e.g., "sd:/")
+ * @param game_code The 4-character game code
+ * @param last_used_filename The filename of the last-used pak (for marking is_last_used)
+ * @param out_list Output list structure to populate
+ * @return vcpak_err_t Error code
+ */
+vcpak_err_t vcpak_list_paks(const char *storage_prefix, const char *game_code,
+                            const char *last_used_filename, vcpak_list_t *out_list);
+
+/**
+ * @brief Free resources allocated by vcpak_list_paks().
+ *
+ * @param list The list to free
+ */
+void vcpak_list_free(vcpak_list_t *list);
+
+
+/*
+ * Pak Operations
+ */
+
+/**
+ * @brief Restore a pak file from SD card to the physical Controller Pak.
+ *
+ * @param pak_path Full path to the .pak file on SD card
+ * @param controller Controller port (0-3)
+ * @return vcpak_err_t Error code
+ */
+vcpak_err_t vcpak_restore_to_physical(const char *pak_path, int controller);
+
+/**
+ * @brief Backup the physical Controller Pak contents to a file on SD card.
+ *
+ * @param pak_path Full path to save the .pak file
+ * @param controller Controller port (0-3)
+ * @return vcpak_err_t Error code
+ */
+vcpak_err_t vcpak_backup_from_physical(const char *pak_path, int controller);
+
+/**
+ * @brief Create a new empty (formatted) pak file.
+ *
+ * @param pak_path Full path where the new .pak file should be created
+ * @return vcpak_err_t Error code
+ */
+vcpak_err_t vcpak_create_empty(const char *pak_path);
+
+/**
+ * @brief Generate a default filename for a new pak.
+ *
+ * Creates a filename like "GameName_001.pak" based on existing files.
+ *
+ * @param storage_prefix The storage prefix
+ * @param game_code The game code
+ * @param game_title The game title (used for filename prefix)
+ * @param out_filename Buffer for the generated filename
+ * @param out_size Size of the output buffer
+ * @return vcpak_err_t Error code
+ */
+vcpak_err_t vcpak_generate_filename(const char *storage_prefix, const char *game_code,
+                                    const char *game_title, char *out_filename, size_t out_size);
+
+
+/*
+ * Dirty State Management
+ */
+
+/**
+ * @brief Save the dirty state to SD card.
+ *
+ * Called just before booting a game to track that a session is in progress.
+ *
+ * @param storage_prefix The storage prefix
+ * @param state The state to save
+ * @return vcpak_err_t Error code
+ */
+vcpak_err_t vcpak_state_save(const char *storage_prefix, const vcpak_state_t *state);
+
+/**
+ * @brief Load the dirty state from SD card.
+ *
+ * @param storage_prefix The storage prefix
+ * @param state Output state structure
+ * @return vcpak_err_t Error code (VCPAK_ERR_FILE_NOT_FOUND if no state file)
+ */
+vcpak_err_t vcpak_state_load(const char *storage_prefix, vcpak_state_t *state);
+
+/**
+ * @brief Clear (delete) the dirty state file.
+ *
+ * Called after successfully backing up the pak on return to menu.
+ *
+ * @param storage_prefix The storage prefix
+ * @return vcpak_err_t Error code
+ */
+vcpak_err_t vcpak_state_clear(const char *storage_prefix);
+
+/**
+ * @brief Check if a dirty state exists.
+ *
+ * @param storage_prefix The storage prefix
+ * @return true if dirty state file exists and is_dirty is set
+ */
+bool vcpak_state_is_dirty(const char *storage_prefix);
+
+#endif /* VIRTUAL_CPAK_H__ */

--- a/src/utils/cpakfs_utils.c
+++ b/src/utils/cpakfs_utils.c
@@ -524,7 +524,6 @@ cpak_io_err_t cpak_restore_from_file(int controller, const char *filepath, cpak_
  * @brief Backup a Controller Pak to a file.
  *
  * Reads all banks from the physical Controller Pak and writes them to a file.
- * The caller is responsible for checking has_cpak() beforehand if needed.
  *
  * @param controller The controller index (0-3).
  * @param filepath The path to the .pak file to write.
@@ -533,6 +532,10 @@ cpak_io_err_t cpak_restore_from_file(int controller, const char *filepath, cpak_
  */
 cpak_io_err_t cpak_backup_to_file(int controller, const char *filepath, cpak_io_context_t *ctx) {
     cpak_io_context_init(ctx);
+
+    if (!has_cpak(controller)) {
+        return CPAK_IO_ERR_NO_PAK;
+    }
 
     int banks = cpak_probe_banks(controller);
     if (ctx) {

--- a/src/utils/cpakfs_utils.c
+++ b/src/utils/cpakfs_utils.c
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <libdragon.h>
 #include <fatfs/ff.h>
 #include <errno.h>

--- a/src/utils/cpakfs_utils.h
+++ b/src/utils/cpakfs_utils.h
@@ -25,6 +25,12 @@
 #define MAX_NUM_NOTES 16
 
 /**
+ * @def CPAK_BANK_SIZE
+ * @brief Size of one Controller Pak bank in bytes (32KB).
+ */
+#define CPAK_BANK_SIZE 32768
+
+/**
  * @struct cpakfs_path_strings_t
  * @brief Structure holding parsed components of a Controller Pak file path.
  *

--- a/src/utils/fs.c
+++ b/src/utils/fs.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <time.h>
 
 #include "fs.h"
 #include "utils.h"
@@ -51,7 +52,7 @@ char *file_basename(char *path) {
  * @param path The path to the file.
  * @return true if the file exists, false otherwise.
  */
-bool file_exists(char *path) {
+bool file_exists(const char *path) {
     struct stat st;
     int error = stat(path, &st);
     return ((error == 0) && S_ISREG(st.st_mode));

--- a/src/utils/fs.h
+++ b/src/utils/fs.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <time.h>
 
 /**
  * @def FS_SECTOR_SIZE
@@ -45,7 +46,7 @@ char *file_basename(char *path);
  * @param path The path to the file.
  * @return true if the file exists, false otherwise.
  */
-bool file_exists(char *path);
+bool file_exists(const char *path);
 
 /**
  * @brief Get the size of a file at the given path.


### PR DESCRIPTION
## Description
Add a Virtual Controller Pak system that automatically manages Controller Pak saves on a per-game basis. When launching a game that supports Controller Pak saves, users can select or create a virtual pak file stored on the SD card. The system automatically restores the pak data to the physical Controller Pak before boot and backs it up when returning to the menu.

Key features:
- Per-game pak file storage (`SD:/cpak_saves/{game_code}/`)
- Pak selection UI when launching Controller Pak games
- Automatic backup/restore cycle
- Dirty state recovery for unexpected power loss
- Last-used pak tracking per ROM

Also includes a refactor extracting shared Controller Pak I/O operations into `cpakfs_utils` for use by both the new virtual pak system and the existing pak manager.

## Motivation and Context
Controller Pak management is tedious. Users must manually back up and restore pak contents when switching between games, or risk save conflicts. This feature eliminates that friction by automating the process, giving each game its own dedicated save space while still using a single physical Controller Pak.

The feature is disabled by default and can be enabled in Settings → Virtual CPak.

## How Has This Been Tested?
- Tested on Analogue 3D
- Verified pak create, restore, backup cycle across multiple games
- Anecdotal: A user on reddit has shared that this feature works using original controller paks (https://www.reddit.com/r/AnalogueInc/comments/1pxt3ao/comment/nyo7b75/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button)

More testing should be done on original hardware. More testing should also be done to confirm that controller pak management continues to work on more than just port 1. Currently I do not have access to original hardware to test with.

## Screenshots
![IMG_3281](https://github.com/user-attachments/assets/8e015418-1091-43d8-81a6-aa67a83e8ecd)

## Types of changes
- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [x] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

Signed-off-by: TheLeggett <david@theleggett.com>
