### PR TITLE
feat: Added Hidden attribute check on filesystem (FAT32/exFAT)

### DIFF
--- a/src/menu/views/browser.c
+++ b/src/menu/views/browser.c
@@ -3,6 +3,7 @@
 #include <miniz_zip.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 
 #include "../cart_load.h"
@@ -10,8 +11,7 @@
 #include "utils/fs.h"
 #include "views.h"
 #include "../sound.h"
-
-
+#include <fat.h>
 
 static const char *archive_extensions[] = { "zip", NULL };
 static const char *cheat_extensions[] = {"cht", "cheats", "datel", "gameshark", NULL};
@@ -58,6 +58,15 @@ static const struct substr hidden_prefixes[] = {
 };
 #define HIDDEN_PREFIXES_COUNT (sizeof(hidden_prefixes) / sizeof(hidden_prefixes[0]))
 
+static bool file_is_fat_hidden (const char *full_path) {
+    struct stat st;
+    
+    if (stat(full_path, &st) == 0) {
+        return FAT_ATTR_IS_HID(&st);
+    }
+    
+    return false;
+}
 
 static bool path_is_hidden (path_t *path) {
     char *stripped_path = strip_fs_prefix(path_get(path));
@@ -79,12 +88,17 @@ static bool path_is_hidden (path_t *path) {
             return true;
         }
     }
+    
     // Check for hidden files based on filename prefix
     for (size_t i = 0; i < HIDDEN_PREFIXES_COUNT; i++) {
         if (basename_len > hidden_prefixes[i].len &&
             strncmp(basename, hidden_prefixes[i].str, hidden_prefixes[i].len) == 0) {
             return true;
         }
+    }
+
+    if (file_is_fat_hidden(stripped_path)) {
+        return true;
     }
 
     return false;

--- a/src/menu/views/browser.c
+++ b/src/menu/views/browser.c
@@ -97,7 +97,7 @@ static bool path_is_hidden (path_t *path) {
         }
     }
 
-    if (file_is_fat_hidden(stripped_path)) {
+    if (file_is_fat_hidden(path_get(path))) {
         return true;
     }
 


### PR DESCRIPTION
Refactor of PR: https://github.com/Polprzewodnikowy/N64FlashcartMenu/pull/315

Files marked as hidden on FAT filesystems are now properly detected and hidden in directory listings.