### PR TITLE
[develop] Fix font path error

### DIFF
--- a/src/menu/fonts.c
+++ b/src/menu/fonts.c
@@ -9,7 +9,7 @@ static void load_default_font (char *custom_font_path) {
 
     if (custom_font_path != NULL && strlen(custom_font_path) > 0) {
         // Only check file_exists if custom_font_path is a valid filesystem path (not rom:/)
-        if (strstr(custom_font_path, "rom:/") == NULL && file_exists(custom_font_path)) {
+        if (strncmp(custom_font_path, "rom:/", 5) != 0 && file_exists(custom_font_path)) {
             font_path = custom_font_path;
         }
     }

--- a/src/menu/fonts.c
+++ b/src/menu/fonts.c
@@ -7,8 +7,11 @@
 static void load_default_font (char *custom_font_path) {
     char *font_path = "rom:/Firple-Bold.font64";
 
-    if (custom_font_path && file_exists(custom_font_path)) {
-        font_path = custom_font_path;
+    if (custom_font_path != NULL && strlen(custom_font_path) > 0) {
+        // Only check file_exists if custom_font_path is a valid filesystem path (not rom:/)
+        if (strstr(custom_font_path, "rom:/") == NULL && file_exists(custom_font_path)) {
+            font_path = custom_font_path;
+        }
     }
 
     rdpq_font_t *default_font = rdpq_font_load(font_path);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Claude sumary:

I have identified the error. The problem lies in the `load_default_font()` function in `fonts.c`, which attempts to use `file_exists()` to check for a custom font file.
The stack trace shows:
`fonts_init()` → `load_default_font()` → `file_exists()`
`file_exists()` calls `stat()`, which fails with the FAT file system error `FR_INT_ERR`
The problem: an attempt is being made to access the file system before it is fully initialized.

Solution: Add a safety check to prevent calling `file_exists()` if the path is invalid or if the file system is not ready:

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->
Issue https://github.com/Polprzewodnikowy/N64FlashcartMenu/issues/338


## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Summercart 64 on a PAL N64

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom font path validation and file existence checks to ensure proper fallback to default font when custom paths are invalid or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->