### PR TITLE
Display calculated total pages instead of hardcoding

### DIFF
--- a/src/menu/views/cpakfs_manager.c
+++ b/src/menu/views/cpakfs_manager.c
@@ -625,7 +625,7 @@ static void draw (menu_t *menu, surface_t *d) {
 
         if (has_mem && !corrupted_pak) {
             style = STL_GREEN;
-            snprintf(free_space_cpak_text, sizeof(free_space_cpak_text), "%d/123 free blocks", cpakfs_stats.pages.total - cpakfs_stats.pages.used);
+            snprintf(free_space_cpak_text, sizeof(free_space_cpak_text), "%d/%d free blocks", cpakfs_stats.pages.total - cpakfs_stats.pages.used, cpakfs_stats.pages.total);
         } else if (has_mem && corrupted_pak) {
             snprintf(has_mem_text, sizeof(has_mem_text), "Controller Pak detected (Corrupted)");
             style = STL_ORANGE;


### PR DESCRIPTION
## Description
Changed the controller pak menu to display the actual total number of pages instead of hardcoding at 123. This is already being calculated, so the change is trivial.

## Motivation and Context
This fixes the total pages shown being incorrect on paks with more than one bank, e.g. Datel/NexGen or Blaze "linear mode" paks.

## How Has This Been Tested?
I tested it by running it on one of my linear mode paks. It's a trivial change.

## Screenshots
<img width="1452" height="1090" alt="image" src="https://github.com/user-attachments/assets/22d1dc5d-cd6a-454b-8c69-fe834f919f30" />

## Types of changes
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.
