### PR TITLE
Add quick-boot of last played game from file browser

### DIFF
--- a/src/menu/actions.c
+++ b/src/menu/actions.c
@@ -5,9 +5,23 @@
 
 #define ACTIONS_REPEAT_DELAY    (8)
 
+/** @brief Frames a button must be held to trigger the "boot last played" action (~0.4s at 30 FPS). */
+#define ACTIONS_BOOT_LAST_HOLD  (12)
+
 
 static int dir_repeat_delay;
 static joypad_8way_t last_dir = JOYPAD_8WAY_NONE;
+static int boot_last_hold_frames;
+
+/**
+ * @brief Test whether the configured "boot last played" button is currently held.
+ *
+ * Kept as a single predicate so the trigger button is easy to change (or make
+ * user-configurable) later. Defaults to the Z button.
+ */
+static bool boot_last_button_held (joypad_buttons_t held) {
+    return held.z;
+}
 
 
 static void actions_clear (menu_t *menu) {
@@ -22,6 +36,7 @@ static void actions_clear (menu_t *menu) {
     menu->actions.options = false;
     menu->actions.settings = false;
     menu->actions.lz_context = false;
+    menu->actions.boot_last = false;
 }
 
 static void actions_update_direction (menu_t *menu) {
@@ -89,7 +104,29 @@ static void actions_update_direction (menu_t *menu) {
     last_dir = held_dir;
 }
 
-static void actions_update_buttons (menu_t *menu) {    
+static void actions_update_hold (menu_t *menu) {
+    joypad_buttons_t held = {0};
+
+    JOYPAD_PORT_FOREACH (i) {
+        held = joypad_get_buttons_held(i);
+        if (held.raw) {
+            break;
+        }
+    }
+
+    if (boot_last_button_held(held)) {
+        boot_last_hold_frames += 1;
+        // Fire exactly once when the hold threshold is first crossed, so the
+        // action does not repeat for as long as the button stays held.
+        if (boot_last_hold_frames == ACTIONS_BOOT_LAST_HOLD) {
+            menu->actions.boot_last = true;
+        }
+    } else {
+        boot_last_hold_frames = 0;
+    }
+}
+
+static void actions_update_buttons (menu_t *menu) {
     joypad_buttons_t pressed = {0};
 
     JOYPAD_PORT_FOREACH (i) {
@@ -125,4 +162,5 @@ void actions_update (menu_t *menu) {
     actions_clear(menu);
     actions_update_direction(menu);
     actions_update_buttons(menu);
+    actions_update_hold(menu);
 }

--- a/src/menu/menu_state.h
+++ b/src/menu/menu_state.h
@@ -114,6 +114,9 @@ typedef struct {
         bool options;
         bool settings;
         bool lz_context;
+
+        /** @brief Quick-boot the most recently played ROM/disk (button held long enough) */
+        bool boot_last;
     } actions;
 
     struct {

--- a/src/menu/views/browser.c
+++ b/src/menu/views/browser.c
@@ -489,12 +489,55 @@ static component_context_menu_t settings_context_menu = {
     }
 };
 
+/**
+ * @brief Quick-boot the most recently played ROM or disk from the browser.
+ *
+ * Reads the top of the history list (index 0 is the most recent entry, see
+ * bookkeeping.c) and boots it directly, skipping the load/info screen. The load
+ * view's init resolves the path from load_history_id; setting the matching
+ * load_pending flag makes its display boot immediately on the next frame
+ * (the same mechanism the autoload feature uses in startup.c). No-op (with an
+ * error sound) when there is no history yet.
+ *
+ * @param menu Pointer to the menu structure.
+ * @return true if a boot was triggered, false otherwise.
+ */
+static bool boot_last_played (menu_t *menu) {
+    bookkeeping_item_t *last = &menu->bookkeeping.history_items[0];
+
+    if (last->bookkeeping_type == BOOKKEEPING_TYPE_EMPTY) {
+        sound_play_effect(SFX_ERROR);
+        return false;
+    }
+
+    menu->load.load_history_id = 0;
+    menu->load.load_favorite_id = -1;
+
+    if (last->bookkeeping_type == BOOKKEEPING_TYPE_DISK) {
+        menu->next_mode = MENU_MODE_LOAD_DISK;
+        menu->load_pending.disk_file = true;
+    } else {
+        menu->next_mode = MENU_MODE_LOAD_ROM;
+        menu->load_pending.rom_file = true;
+    }
+
+    sound_play_effect(SFX_ENTER);
+    return true;
+}
+
 static void process (menu_t *menu) {
     if (ui_components_context_menu_process(menu, menu->browser.archive ? &archive_context_menu : &entry_context_menu)) {
         return;
     }
 
     if (ui_components_context_menu_process(menu, &settings_context_menu)) {
+        return;
+    }
+
+    // Quick-boot last played (held button). Browser-only so it never collides
+    // with the Z/L "extra info" / "load with ROM" actions in the load views.
+    if (menu->actions.boot_last) {
+        boot_last_played(menu);
         return;
     }
 

--- a/src/menu/views/load_disk.c
+++ b/src/menu/views/load_disk.c
@@ -327,6 +327,11 @@ void view_load_disk_init (menu_t *menu) {
         menu->load.disk_slots.primary.disk_path = NULL;
     }
 
+    // A quick-boot from the browser presets load_pending.disk_file to request an
+    // immediate boot (skipping the info screen). Capture that intent, then clear
+    // the flag so every early-return error path leaves it false; it is only
+    // re-armed at the end once init has fully succeeded.
+    bool boot_now = menu->load_pending.disk_file;
     menu->load_pending.disk_file = false;
 
     if(menu->load.load_history_id != -1 || menu->load.load_favorite_id != -1) {
@@ -365,8 +370,15 @@ void view_load_disk_init (menu_t *menu) {
         if(!load_rom(menu, items[item_id].secondary_path)) {
             return;  // load_rom handles its own error messages
         }
+
+        // For a quick-boot, honor how the entry was last played: boot the disk
+        // with its companion ROM if it had one (load_rom populated rom_path).
+        if (boot_now) {
+            menu->load.combined_disk_rom = (menu->load.rom_path != NULL);
+        }
     } else {
-        // Existing browser path logic
+        // Quick-boot only applies to history/favorite entries, not raw browsing.
+        boot_now = false;
         menu->load.disk_slots.primary.disk_path = path_clone_push(menu->browser.directory, menu->browser.entry->name);
     }
 
@@ -382,6 +394,11 @@ void view_load_disk_init (menu_t *menu) {
 
     ui_components_context_menu_init(&options_context_menu);
     boxart = ui_components_boxart_init(menu->storage_prefix, menu->load.disk_slots.primary.disk_info.id, NULL, IMAGE_BOXART_FRONT);
+
+    // Init fully succeeded: re-arm the immediate boot requested by quick-boot.
+    if (boot_now) {
+        menu->load_pending.disk_file = true;
+    }
 }
 
 void view_load_disk_display (menu_t *menu, surface_t *display) {

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -712,6 +712,9 @@ void view_load_rom_init (menu_t *menu) {
         //disable the attempt at loading the favorite / history
         menu->load.load_history_id = -1;
         menu->load.load_favorite_id = -1;
+        // Cancel any pending auto/quick boot so a failed load does not leave the
+        // flag set and instantly boot on the next entry to this view.
+        menu->load_pending.rom_file = false;
         // FIXME: use bookkeeping_favorite_remove() here instead of just showing an error and leaving the broken favorite / history item in place
         menu_show_error(menu, convert_error_message(err));
         return;


### PR DESCRIPTION
## Description

Adds a way to jump straight back into the most recently played game from the
file browser: **hold Z for ~0.4s** and the menu boots `history_items[0]` (the
top of the existing history list) directly, skipping the load/info screen.

A short *hold* (rather than a tap) is required so it reads as a deliberate
action and avoids accidental launches. Today the only way to re-launch the last
game is to tab over to the History view and select it; this is a one-button
shortcut for that common case.

The change is intentionally small and additive. A quick summary of each file:

- **`actions.c`** — adds held-button detection. A new `actions_update_hold()`
  uses `joypad_get_buttons_held()` with a frame threshold
  (`ACTIONS_BOOT_LAST_HOLD`, ~0.4s at 30 FPS) and sets a new
  `actions.boot_last` once when the threshold is first crossed (so it fires
  once per hold, not every frame). The trigger button is isolated in a single
  `boot_last_button_held()` predicate (currently Z) to make it easy to change
  or expose as a setting later. Existing input handling is untouched.
- **`menu_state.h`** — adds the `actions.boot_last` flag.
- **`browser.c`** — adds `boot_last_played()` and an early check in
  `process()`. It sets `load_history_id = 0` and the matching `load_pending`
  flag, then routes to the existing `MENU_MODE_LOAD_ROM` / `MENU_MODE_LOAD_DISK`
  view — the same boot mechanism the autoload feature uses in `startup.c`. It
  is **browser-only**, so it does not collide with the existing Z/L "extra
  info" (ROM) and "load with ROM" (disk) actions in the load views. No-op with
  an error sound when history is empty.
- **`load_disk.c`** — disks differ from ROMs: the disk info screen normally
  waits for A (disk only) or Z/L (disk + companion ROM), and unlike the ROM
  view, `view_load_disk_init()` resets `load_pending.disk_file`. To boot a disk
  directly without changing that behavior, the quick-boot intent is captured
  into a local (`boot_now`) **before** the existing reset (the reset itself is
  not moved), and re-armed only after init fully succeeds. `combined_disk_rom`
  is derived from whether the history entry had a companion ROM, so the disk
  boots the way it was last played. Every early-return error path leaves the
  flag false.
- **`load_rom.c`** — clears `load_pending.rom_file` on a ROM-info load error,
  so a failed quick/auto boot cannot instantly re-trigger on the next entry to
  the view (also hardens the existing autoload path).

No existing statements are reordered; the changes are additive or
"read-the-flag-then-do-the-original-thing" wrappers.

### Known limitation (64DD disks with a companion ROM)

When quick-booting a 64DD disk, this reuses the companion ROM that was
recorded with the history entry: if the entry has a secondary ROM path it
boots "with ROM", otherwise disk-only. This mirrors what the History tab
already does when it pre-fills the companion ROM for a disk entry.

One nuance I ran into while testing: a history entry stores whatever
`rom_path` was set when the disk was launched, so it's possible for a disk
to carry a companion ROM in its history entry even if that ROM wasn't
actually needed (for example, if a ROM had been opened just before loading
a standalone disk like SimCity 64). From the disk info screen the user can
choose A (disk only) vs Z/L (load with ROM) and notice the difference;
quick-boot skips that screen, so in that specific situation it would boot
the disk with the recorded ROM attached. It's harmless and recoverable
(launch the disk directly from the browser to boot it standalone), and disks
that genuinely need their ROM — e.g. F-Zero X Expansion Kit — quick-boot
correctly.

I left this as-is to keep the change focused and consistent with the
existing history behavior, but I'm very happy to adjust the approach if
you'd prefer a different default for disks. Wanted to flag it transparently
since I hit it in testing.

## Motivation and Context

Quality-of-life: getting back into the game you were just playing currently
takes navigating to the History tab and choosing the entry. A single held
button makes the most common re-launch instant. It reuses the existing history
bookkeeping and load-view machinery rather than introducing a new code path.

No open issue is being closed; happy to link one if preferred.

## How Has This Been Tested?

- **Built** with the project's libdragon toolchain (`make all`, `FLAGS=-DNDEBUG`).
- **Hardware:** verified on a real **SummerCart64**. Confirmed:
  - Holding Z in the browser boots the most recently played **ROM** directly.
  - Holding Z boots the most recently played **64DD (.ndd) disk**, including
    the "with companion ROM" case, matching how it was last launched.
  - A short tap does nothing (no accidental launch).
  - Empty history plays the error sound and does nothing.
  - The existing Z/L actions in the ROM/disk info screens are unaffected.
- I only have a SummerCart64, so other carts were not
  hardware-tested, but the change is in cart-agnostic menu code only.

_Developed with AI assistance; all changes were reviewed and verified on real
hardware by me._

## Screenshots

N/A (no visible UI change in this PR; the action is a held button in the
browser).

## Types of changes

- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. <!-- project has no automated test suite -->
- [x] All new and existing tests passed. <!-- builds cleanly; verified manually on SC64 hardware -->


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

Signed-off-by: jza103 <30602354+jza103@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “boot last played” action that can be triggered by holding a button long enough, letting you quickly launch the most recently used ROM or disk.
  * Improved quick-boot flow so the selected item launches immediately from the browser and load screens.

* **Bug Fixes**
  * Fixed a case where failed ROM loading could leave a boot flag active and cause an unexpected launch later.
  * Improved handling for disk-based launches so quick-boot behavior is preserved correctly across navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->