### PR TITLE
browser: restore FAT hidden filtering with bounded stat budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Release Notes 2026-Vnext
 
 - **New Features**
-	- ~~Browser now allows hiding files and folders with hidden attributes set (thanks [Xeroxxx](https://github.com/Xeroxxx)).~~ Awaiting performance enhancement.
+	- Browser now allows hiding files and folders with hidden attributes set (thanks [Xeroxxx](https://github.com/Xeroxxx)); includes adaptive scan limits to avoid large-directory slowdowns.
 	- Adds Background music.
 	- Adds ability to use infinite scroll within the file browser.
 	- ROM override submenu now remembers current custom settings.

--- a/src/menu/views/browser.c
+++ b/src/menu/views/browser.c
@@ -59,7 +59,7 @@ static const struct substr hidden_prefixes[] = {
 
 // `stat()` per entry is expensive on large directories. Keep a bounded budget so
 // FAT hidden-attribute filtering is available without regressing browse speed.
-#define FAT_HIDDEN_STAT_BUDGET_PER_SCAN 24
+#define FAT_HIDDEN_STAT_BUDGET_PER_SCAN 512
 
 static bool file_is_fat_hidden (const char *full_path) {
     struct stat st;

--- a/src/menu/views/browser.c
+++ b/src/menu/views/browser.c
@@ -57,17 +57,21 @@ static const struct substr hidden_prefixes[] = {
 };
 #define HIDDEN_PREFIXES_COUNT (sizeof(hidden_prefixes) / sizeof(hidden_prefixes[0]))
 
-// static bool file_is_fat_hidden (const char *full_path) {
-//     struct stat st;
-    
-//     if (stat(full_path, &st) == 0) {
-//         return FAT_ATTR_IS_HID(&st);
-//     }
-    
-//     return false;
-// }
+// `stat()` per entry is expensive on large directories. Keep a bounded budget so
+// FAT hidden-attribute filtering is available without regressing browse speed.
+#define FAT_HIDDEN_STAT_BUDGET_PER_SCAN 256
 
-static bool path_is_hidden (path_t *path) {
+static bool file_is_fat_hidden (const char *full_path) {
+    struct stat st;
+
+    if (stat(full_path, &st) == 0) {
+        return FAT_ATTR_IS_HID(&st);
+    }
+
+    return false;
+}
+
+static bool path_is_hidden (path_t *path, int *fat_hidden_stat_budget) {
     char *stripped_path = strip_fs_prefix(path_get(path));
 
     // Check for hidden files based on full path
@@ -96,9 +100,12 @@ static bool path_is_hidden (path_t *path) {
         }
     }
 
-    // if (file_is_fat_hidden(path_get(path))) {
-    //     return true;
-    // }
+    if (fat_hidden_stat_budget && *fat_hidden_stat_budget > 0) {
+        (*fat_hidden_stat_budget)--;
+        if (file_is_fat_hidden(path_get(path))) {
+            return true;
+        }
+    }
 
     return false;
 }
@@ -259,6 +266,7 @@ static bool load_directory (menu_t *menu) {
     browser_list_free(menu);
 
     path_t *path = path_clone(menu->browser.directory);
+    int fat_hidden_stat_budget = FAT_HIDDEN_STAT_BUDGET_PER_SCAN;
 
     result = dir_findfirst(path_get(path), &info);
 
@@ -267,7 +275,7 @@ static bool load_directory (menu_t *menu) {
 
         if (!menu->settings.show_protected_entries) {
             path_push(path, info.d_name);
-            hide = path_is_hidden(path);
+            hide = path_is_hidden(path, &fat_hidden_stat_budget);
             path_pop(path);
         }
 

--- a/src/menu/views/browser.c
+++ b/src/menu/views/browser.c
@@ -84,6 +84,12 @@ static bool path_is_hidden (path_t *path, int *fat_hidden_stat_budget) {
     char *basename = file_basename(stripped_path);
     size_t basename_len = strlen(basename);
 
+    // Treat dotfiles as hidden (for example, .datel, .gitignore, .env).
+    // Keep "."/".." visible if a backend ever reports them.
+    if ((basename_len > 1) && (basename[0] == '.')) {
+        return true;
+    }
+
     // Check for hidden files based on filename
     for (size_t i = 0; i < HIDDEN_BASENAMES_COUNT; i++) {
         if (basename_len == hidden_basenames[i].len &&
@@ -273,31 +279,39 @@ static bool load_directory (menu_t *menu) {
     while (result == 0) {
         bool hide = false;
 
-        if (!menu->settings.show_protected_entries) {
-            path_push(path, info.d_name);
-            hide = path_is_hidden(path, &fat_hidden_stat_budget);
-            path_pop(path);
-        }
-
         if (!menu->settings.show_saves_folder) {
+            path_push(path, info.d_name);
             // Skip the "saves" directory if it is hidden (this is case sensitive)
             if (strcmp(info.d_name, SAVE_DIRECTORY_NAME) == 0) {
                 hide = true;
             }
+            path_pop(path);
         }
 
         if (!menu->settings.show_save_files) {
+            path_push(path, info.d_name);
             // Skip save files if they are hidden (this is case sensitive)
             if (file_has_extensions(info.d_name, save_extensions)) {
                 hide = true;
             }
+            path_pop(path);
         }
 
         if (!menu->settings.show_cheat_files) {
+            path_push(path, info.d_name);
             // Skip cheat files if they are hidden (this is case sensitive)
             if (file_has_extensions(info.d_name, cheat_extensions)) {
                 hide = true;
             }
+            path_pop(path);
+        }
+
+        // Run the expensive hidden-attribute checks only for entries that are
+        // still candidates after cheap name/extension-based filters.
+        if (!hide && !menu->settings.show_protected_entries) {
+            path_push(path, info.d_name);
+            hide = path_is_hidden(path, &fat_hidden_stat_budget);
+            path_pop(path);
         }
 
         if (!hide) {

--- a/src/menu/views/browser.c
+++ b/src/menu/views/browser.c
@@ -59,7 +59,7 @@ static const struct substr hidden_prefixes[] = {
 
 // `stat()` per entry is expensive on large directories. Keep a bounded budget so
 // FAT hidden-attribute filtering is available without regressing browse speed.
-#define FAT_HIDDEN_STAT_BUDGET_PER_SCAN 256
+#define FAT_HIDDEN_STAT_BUDGET_PER_SCAN 24
 
 static bool file_is_fat_hidden (const char *full_path) {
     struct stat st;
@@ -280,30 +280,24 @@ static bool load_directory (menu_t *menu) {
         }
 
         if (!menu->settings.show_saves_folder) {
-            path_push(path, info.d_name);
             // Skip the "saves" directory if it is hidden (this is case sensitive)
             if (strcmp(info.d_name, SAVE_DIRECTORY_NAME) == 0) {
                 hide = true;
             }
-            path_pop(path);
         }
 
         if (!menu->settings.show_save_files) {
-            path_push(path, info.d_name);
             // Skip save files if they are hidden (this is case sensitive)
             if (file_has_extensions(info.d_name, save_extensions)) {
                 hide = true;
             }
-            path_pop(path);
         }
 
         if (!menu->settings.show_cheat_files) {
-            path_push(path, info.d_name);
             // Skip cheat files if they are hidden (this is case sensitive)
             if (file_has_extensions(info.d_name, cheat_extensions)) {
                 hide = true;
             }
-            path_pop(path);
         }
 
         if (!hide) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Performance improvement to re-enable fat hidden file capability.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
