### PR TITLE
Fix/rtyi blank screen with background

### DIFF
--- a/src/boot/boot.c
+++ b/src/boot/boot.c
@@ -93,6 +93,12 @@ void boot (boot_params_t *params) {
     cpu_io_write(&AI->MADDR, 0);
     cpu_io_write(&AI->LEN, 0);
 
+    // Clear DPC status flags and reset command buffer to known-empty state at address 0
+    cpu_io_write(&DPC->SR, DPC_SR_CLR_XBUS_DMEM_DMA | DPC_SR_CLR_FREEZE | DPC_SR_CLR_FLUSH);
+    while (cpu_io_read(&DPC->SR) & (DPC_SR_PIPE_BUSY | DPC_SR_CMD_BUSY | DPC_SR_DMA_BUSY | DPC_SR_TMEM_BUSY));
+    cpu_io_write(&DPC->START, 0);
+    cpu_io_write(&DPC->END, 0);
+
     while (cpu_io_read(&SP->SR) & SP_SR_DMA_BUSY);
 
     uint32_t *reboot_src = &reboot_start;
@@ -115,10 +121,6 @@ void boot (boot_params_t *params) {
     cpu_io_write(&PI->DOM[0].PWD, pi_config >> 8);
     cpu_io_write(&PI->DOM[0].PGS, pi_config >> 16);
     cpu_io_write(&PI->DOM[0].RLS, pi_config >> 20);
-
-    if (cpu_io_read(&DPC->SR) & DPC_SR_XBUS_DMEM_DMA) {
-        while (cpu_io_read(&DPC->SR) & DPC_SR_PIPE_BUSY);
-    }
 
     io32_t *ipl3_src = base;
     io32_t *ipl3_dst = SP_MEM->DMEM;

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -167,10 +167,10 @@ static void menu_deinit (menu_t *menu) {
     display_close();
 
     sound_deinit();
-    
-    rspq_wait();  // Execute deferred callbacks before closing RSPQ
-    rspq_close();
+
+    rspq_wait();
     rdpq_close();
+    rspq_close();
     rtc_close();
     timer_close();
     joypad_close();

--- a/src/menu/ui_components/background.c
+++ b/src/menu/ui_components/background.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "../ui_components.h"
 #include "constants.h"
@@ -204,6 +205,12 @@ void ui_components_background_init(char *cache_location) {
 void ui_components_background_free(void) {
     if (background) {
         if (background->image) {
+            // Zero RDRAM before freeing; stale pixel data can corrupt game BSS if not overwritten by IPL3
+            if (background->image->buffer) {
+                size_t size = background->image->height * background->image->stride;
+                memset(background->image->buffer, 0, size);
+                data_cache_hit_writeback_invalidate(background->image->buffer, size);
+            }
             surface_free(background->image);
             free(background->image);
             background->image = NULL;

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -6,6 +6,7 @@
 #include "boot/boot.h"
 #include "utils/fs.h"
 #include "views.h"
+#include "../ui_components/constants.h"
 #include <string.h>
 
 static bool show_extra_info_message = false;
@@ -562,7 +563,7 @@ static void process (menu_t *menu) {
 static void draw (menu_t *menu, surface_t *d) {
     rdpq_attach(d, NULL);
 
-    ui_components_background_draw();
+    rdpq_clear(BACKGROUND_EMPTY_COLOR);
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     if (menu->load_pending.rom_file && menu->settings.loading_progress_bar_enabled) {
         ui_components_loader_draw(0.0f, NULL);
@@ -698,7 +699,7 @@ static void draw_progress (float progress) {
     if (d) {
         rdpq_attach(d, NULL);
 
-        ui_components_background_draw();
+        rdpq_clear(BACKGROUND_EMPTY_COLOR);
 
         ui_components_loader_draw(progress, "Loading ROM...");  
 

--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -6,7 +6,6 @@
 #include "boot/boot.h"
 #include "utils/fs.h"
 #include "views.h"
-#include "../ui_components/constants.h"
 #include <string.h>
 
 static bool show_extra_info_message = false;
@@ -563,7 +562,7 @@ static void process (menu_t *menu) {
 static void draw (menu_t *menu, surface_t *d) {
     rdpq_attach(d, NULL);
 
-    rdpq_clear(BACKGROUND_EMPTY_COLOR);
+    ui_components_background_draw();
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     if (menu->load_pending.rom_file && menu->settings.loading_progress_bar_enabled) {
         ui_components_loader_draw(0.0f, NULL);
@@ -699,7 +698,7 @@ static void draw_progress (float progress) {
     if (d) {
         rdpq_attach(d, NULL);
 
-        rdpq_clear(BACKGROUND_EMPTY_COLOR);
+        ui_components_background_draw();
 
         ui_components_loader_draw(progress, "Loading ROM...");  
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
## Fix RTYI blank screen when a background image is set

### Problem

Launching certain ROMs (notably the RTYI demo) from the menu resulted in a blank screen whenever a background image was cached. The issue was absent with no background set.

### Root Cause

The background image buffer (up to 460 KB for a 640×360 RGBA16 image) was allocated from the N64 heap and written to by the RDP via DMA. When freed, only the heap bookkeeping was updated — the pixel data (e.g. `0xC710...`) remained in RDRAM.

When a small ROM's IPL3 copies the game to RDRAM, it only covers the game's own footprint. If the freed image area lies beyond that, and the game does not fully zero its BSS (a common shortcut in demos), it reads stale pixel values instead of zeros. This corrupts initialisation logic and produces a blank screen.

### Fix

Zero the image buffer and flush the CPU write-back cache before freeing the surface in `ui_components_background_free()`. This guarantees RDRAM is clean for any game, regardless of its size or BSS initialisation strategy.

### Additional clean-ups

- **boot.c**: Reset DPC status flags and command buffer to a known-empty state before handing off to IPL3; remove the now-redundant XBUS conditional pipe-busy wait (libdragon's RSPQ never uses XBUS mode)
- **menu.c**: Close `rdpq` before `rspq` (correct teardown order — `rdpq` is layered on top of `rspq` and must be torn down first)

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
