### PR TITLE
Background image improvements: remove option and decode quality fixes

### DIFF
--- a/src/menu/ui_components.h
+++ b/src/menu/ui_components.h
@@ -198,6 +198,11 @@ void ui_components_background_init(char *cache_location);
 void ui_components_background_free(void);
 
 /**
+ * @brief Free and delete the cached background image.
+ */
+void ui_components_background_clear(void);
+
+/**
  * @brief Replace the background image.
  * 
  * @param image New background image.
@@ -208,6 +213,21 @@ void ui_components_background_replace_image(surface_t *image);
  * @brief Draw the background component.
  */
 void ui_components_background_draw(void);
+
+/**
+ * @brief Return the current background image surface, or NULL if none is set.
+ */
+surface_t *ui_components_background_get_image(void);
+
+/**
+ * @brief Reload the background image from cache (call after temporarily freeing).
+ */
+void ui_components_background_reload(void);
+
+/**
+ * @brief Free only the in-memory image and display list, keeping the cache intact.
+ */
+void ui_components_background_image_free_only(void);
 
 /**
  * @brief Draw the file list component.

--- a/src/menu/ui_components/background.c
+++ b/src/menu/ui_components/background.c
@@ -220,6 +220,26 @@ void ui_components_background_free(void) {
     }
 }
 
+void ui_components_background_clear(void) {
+    if (!background) {
+        return;
+    }
+    if (background->cache_location) {
+        remove(background->cache_location);
+    }
+    // Free image and display list but keep the struct and cache_location so
+    // a new background can be set without rebooting
+    if (background->image) {
+        surface_free(background->image);
+        free(background->image);
+        background->image = NULL;
+    }
+    if (background->image_display_list) {
+        rdpq_call_deferred(display_list_free, background->image_display_list);
+        background->image_display_list = NULL;
+    }
+}
+
 /**
  * @brief Replace the background image and update cache/display list.
  *
@@ -254,5 +274,35 @@ void ui_components_background_draw(void) {
         rspq_block_run(background->image_display_list);
     } else {
         rdpq_clear(BACKGROUND_EMPTY_COLOR);
+    }
+}
+
+surface_t *ui_components_background_get_image(void) {
+    return background ? background->image : NULL;
+}
+
+void ui_components_background_reload(void) {
+    if (!background || !background->cache_location) {
+        return;
+    }
+    if (!background->image) {
+        load_from_cache(background);
+        prepare_background(background);
+    }
+}
+
+void ui_components_background_image_free_only(void) {
+    if (!background) {
+        return;
+    }
+    // Free image and display list, keep struct+cache_location so it can be reloaded
+    if (background->image) {
+        surface_free(background->image);
+        free(background->image);
+        background->image = NULL;
+    }
+    if (background->image_display_list) {
+        rdpq_call_deferred(display_list_free, background->image_display_list);
+        background->image_display_list = NULL;
     }
 }

--- a/src/menu/views/image_viewer.c
+++ b/src/menu/views/image_viewer.c
@@ -24,16 +24,6 @@ static char *convert_error_message (png_err_t err) {
     }
 }
 
-/** Max image dimension that fits in 80% of free heap (2 bytes/pixel). */
-static int image_budget_max_dimension (void) {
-    heap_stats_t heap;
-    sys_get_heap_stats(&heap);
-    size_t budget = (size_t)((heap.total - heap.used) * 0.8f);
-    int dim = (int)sqrtf((float)(budget / 2));
-    if (dim < 16) dim = 16;
-    return dim;
-}
-
 static void image_callback (png_err_t err, surface_t *decoded_image, void *callback_data) {
     menu_t *menu = (menu_t *) (callback_data);
 
@@ -119,6 +109,8 @@ static void deinit (menu_t *menu) {
         } else {
             surface_free(image);
             free(image);
+            // Restore the background that was freed at init to give the decoder more memory
+            ui_components_background_reload();
         }
     }
     image = NULL;
@@ -130,9 +122,11 @@ void view_image_viewer_init (menu_t *menu) {
     image_loading = true;
     image_set_as_background = false;
     image = NULL;
-    int max_dim = image_budget_max_dimension();
-    int max_w = (max_dim > display_get_width()) ? display_get_width() : max_dim;
-    int max_h = (max_dim > display_get_height()) ? display_get_height() : max_dim;
+    // Free the background image temporarily so the PNG decoder has its full memory budget;
+    // ui_components_background_reload() restores it if the user does not set a new background
+    ui_components_background_image_free_only();
+    int max_w = display_get_width();
+    int max_h = display_get_height();
 
     path_t *path = path_clone_push(menu->browser.directory, menu->browser.entry->name);
 

--- a/src/menu/views/settings_editor.c
+++ b/src/menu/views/settings_editor.c
@@ -128,6 +128,12 @@ static void set_rumble_enabled_type (menu_t *menu, void *arg) {
 // }
 #endif
 
+static void remove_background_image (menu_t *menu, void *arg) {
+    (void)arg;
+    (void)menu;
+    ui_components_background_clear();
+}
+
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
 static int get_loading_progress_bar_enabled_current_selection (menu_t *menu) {
     return menu->settings.loading_progress_bar_enabled ? 0 : 1;
@@ -323,6 +329,7 @@ static component_context_menu_t options_context_menu = { .list = {
     { .text = "Rumble Feedback", .submenu = &set_rumble_enabled_type_context_menu },
     // { .text = "Restore Defaults", .action = set_use_default_settings },
 #endif
+    { .text = "Remove Background", .action = remove_background_image },
 
     COMPONENT_CONTEXT_MENU_LIST_END,
 }};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
## Background image improvements

### Problem

Three related issues were found in the background image feature:

1. **No way to remove a background without manually deleting the SD card file.**
2. **PNG decode quality degraded when replacing an existing background.**
   - The PNG decoder has an internal loop that halves output dimensions when
     heap is tight (`row_size + surf_size + 64 KB <= available`). With a 460 KB
     background image already resident in memory, there was insufficient free
     heap to decode a 640×360 PNG at full resolution — it would silently
     downscale to 320×180.
3. **The initial `image_budget_max_dimension` calculation in the image viewer was
   mathematically incorrect** when it tried to add "background headroom" to the
   budget by adding two separately-derived sqrt values rather than adding the raw
   bytes to the free pool before computing the dimension.

### Changes

#### Settings: Remove Background option

A new **"Remove Background"** entry has been added to the Settings context menu.
It calls `ui_components_background_clear()` which:
- Removes the cache file from the SD card (`/menu/cache/background.data`)
- Frees the in-memory surface and display list
- Keeps the background component struct alive so a new background can be set
  in the same session without rebooting

#### PNG decode quality fix

Before starting a PNG decode in the image viewer, the existing background image
is now freed via `ui_components_background_image_free_only()`. This gives the
PNG decoder its full memory budget, ensuring a 640×360 source image is stored
at 640×360 (460 816 bytes) rather than being silently halved to 320×180
(115 216 bytes).

If the user cancels (does not confirm setting the image as background),
`ui_components_background_reload()` restores the previous background from the
on-disk cache.

#### Image viewer decode cap simplified

`image_budget_max_dimension()` has been removed. The initial decode cap is now
simply `display_get_width() × display_get_height()` (640×480), matching the
maximum useful size for the display. The PNG decoder's own internal memory loop
correctly handles any remaining pressure on tight 4 MB systems.

This function was `static` and only used in `image_viewer.c`; box art
(`BOXART_WIDTH_MAX / BOXART_HEIGHT_MAX`) and music player images are unaffected.

### Files changed

| File | Change |
|------|--------|
| `src/menu/ui_components/background.c` | Add `ui_components_background_clear()`, `ui_components_background_image_free_only()`, `ui_components_background_reload()` |
| `src/menu/ui_components.h` | Declare the three new functions |
| `src/menu/views/image_viewer.c` | Free background before decode; reload on cancel; simplify decode cap |
| `src/menu/views/settings_editor.c` | Add **"Remove Background"** action |

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>