### PR TITLE
Fix MP3 append error

### DIFF
--- a/src/menu/audio_player.c
+++ b/src/menu/audio_player.c
@@ -562,6 +562,13 @@ audioplayer_err_t audioplayer_init (void) {
         .frequency = 44100,
         .len = WAVEFORM_MAX_LEN - 1,
         .loop_len = WAVEFORM_MAX_LEN - 1,
+        // The decoder appends whole codec frames at a time (up to 1152
+        // samples for MP3/FLAC). Declare that granularity so the samplebuffer
+        // sizes its mirrored tail (margin) to cover a single frame append
+        // that wraps around the ring. Without this, appending a full frame
+        // near the ring end trips the assertion in samplebuffer_append:
+        // "append of %x units wraps and does not fit the margin".
+        .append_units = MINIMP3_MAX_SAMPLES_PER_FRAME / 2,
         .read = mp3player_wave_read,
         .ctx = p,
     };

--- a/src/menu/audio_player.c
+++ b/src/menu/audio_player.c
@@ -562,12 +562,6 @@ audioplayer_err_t audioplayer_init (void) {
         .frequency = 44100,
         .len = WAVEFORM_MAX_LEN - 1,
         .loop_len = WAVEFORM_MAX_LEN - 1,
-        // The decoder appends whole codec frames at a time (up to 1152
-        // samples for MP3/FLAC). Declare that granularity so the samplebuffer
-        // sizes its mirrored tail (margin) to cover a single frame append
-        // that wraps around the ring. Without this, appending a full frame
-        // near the ring end trips the assertion in samplebuffer_append:
-        // "append of %x units wraps and does not fit the margin".
         .append_units = MINIMP3_MAX_SAMPLES_PER_FRAME / 2,
         .read = mp3player_wave_read,
         .ctx = p,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix an error that happens when load a MP3 that says: samplebuffer_append: append of 480 units wraps and does not fit the margin (slot:480 margin:80): declare it in waveform_t::append_units.
## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
