### PR TITLE
Fix/audio player bugfixes

### DIFF
--- a/src/menu/audio_player.c
+++ b/src/menu/audio_player.c
@@ -583,6 +583,7 @@ void audioplayer_deinit (void) {
 }
 
 audioplayer_err_t audioplayer_load (char *path) {
+    if (!p) return AUDIOPLAYER_ERR_OUT_OF_MEM;
     if (p->current.loaded) {
         audioplayer_stop();
         track_unload(&p->current);
@@ -598,6 +599,7 @@ audioplayer_err_t audioplayer_load (char *path) {
 }
 
 void audioplayer_unload (void) {
+    if (!p) return;
     audioplayer_stop();
     track_unload(&p->current);
 }
@@ -622,11 +624,12 @@ bool audioplayer_is_playing (void) {
 }
 
 bool audioplayer_is_finished (void) {
-    if (!p->current.loaded) return false;
+    if (!p || !p->current.loaded) return false;
     return track_is_finished(&p->current);
 }
 
 audioplayer_err_t audioplayer_play (void) {
+    if (!p) return AUDIOPLAYER_ERR_OUT_OF_MEM;
     if (!p->current.loaded) return AUDIOPLAYER_ERR_NO_FILE;
 
     if (!audioplayer_is_playing()) {
@@ -654,6 +657,7 @@ void audioplayer_stop (void) {
 }
 
 audioplayer_err_t audioplayer_toggle (void) {
+    if (!p) return AUDIOPLAYER_ERR_OUT_OF_MEM;
     if (audioplayer_is_playing()) {
         audioplayer_stop();
     } else {
@@ -668,6 +672,7 @@ void audioplayer_mute (bool mute) {
 }
 
 audioplayer_err_t audioplayer_seek (int seconds) {
+    if (!p) return AUDIOPLAYER_ERR_OUT_OF_MEM;
     if (!p->current.loaded) return AUDIOPLAYER_ERR_NO_FILE;
 
     if (p->current.format == AUDIO_FORMAT_FLAC) {
@@ -731,22 +736,22 @@ audioplayer_err_t audioplayer_seek (int seconds) {
 }
 
 float audioplayer_get_duration (void) {
-    if (!p->current.loaded) return 0.0f;
+    if (!p || !p->current.loaded) return 0.0f;
     return p->current.duration;
 }
 
 float audioplayer_get_bitrate (void) {
-    if (!p->current.loaded) return 0.0f;
+    if (!p || !p->current.loaded) return 0.0f;
     return p->current.bitrate;
 }
 
 int audioplayer_get_samplerate (void) {
-    if (!p->current.loaded) return 0;
+    if (!p || !p->current.loaded) return 0;
     return p->current.samplerate;
 }
 
 int audioplayer_get_native_samplerate (void) {
-    if (!p->current.loaded) return 0;
+    if (!p || !p->current.loaded) return 0;
     if (p->current.format == AUDIO_FORMAT_FLAC && p->current.native_rate > 0) {
         return p->current.native_rate;
     }
@@ -754,7 +759,7 @@ int audioplayer_get_native_samplerate (void) {
 }
 
 float audioplayer_get_progress (void) {
-    if (!p->current.loaded) return 0.0f;
+    if (!p || !p->current.loaded) return 0.0f;
 
     float progress;
 

--- a/src/menu/audio_player.c
+++ b/src/menu/audio_player.c
@@ -97,7 +97,12 @@ static size_t drflac_read_cb (void *userdata, void *buf, size_t bytes) {
 
 static drflac_bool32 drflac_seek_cb (void *userdata, int offset, drflac_seek_origin origin) {
     flac_io_t *io = (flac_io_t *)userdata;
-    int whence = (origin == DRFLAC_SEEK_SET) ? SEEK_SET : SEEK_CUR;
+    int whence;
+    switch (origin) {
+        case DRFLAC_SEEK_SET: whence = SEEK_SET; break;
+        case DRFLAC_SEEK_END: whence = SEEK_END; break;
+        default:              whence = SEEK_CUR; break;
+    }
     return fseek(io->f, offset, whence) == 0;
 }
 
@@ -442,13 +447,13 @@ static void mp3player_wave_read (void *ctx, samplebuffer_t *sbuf, int wpos, int 
     audio_track_t *t = &p->current;
 
     if (!t->loaded) {
-        write_silence(sbuf, wlen, 2);
+        write_silence(sbuf, wlen, p->wave.channels);
         return;
     }
 
     if (t->format == AUDIO_FORMAT_FLAC) {
         if (!t->flac) {
-            write_silence(sbuf, wlen, 2);
+            write_silence(sbuf, wlen, p->wave.channels);
             return;
         }
 
@@ -507,7 +512,7 @@ static void mp3player_wave_read (void *ctx, samplebuffer_t *sbuf, int wpos, int 
 
     /* MP3 decode path */
     if (!t->f) {
-        write_silence(sbuf, wlen, 2);
+        write_silence(sbuf, wlen, p->wave.channels);
         return;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fix FLAC end-relative seeking: drflac_seek_cb incorrectly mapped all
  non-DRFLAC_SEEK_SET origins to SEEK_CUR, causing end-relative seeks
  (DRFLAC_SEEK_END) to be positioned incorrectly. Now explicitly maps
  DRFLAC_SEEK_END to SEEK_END.

- Fix write_silence channel count: mp3player_wave_read had three early-return
  paths that called write_silence with hardcoded channel count 2 instead of
  using waveform's actual p->wave.channels. This could cause incorrect buffer
  allocation for mono formats. Now uses p->wave.channels in all calls.

After audioplayer_deinit() sets the global player pointer p to NULL, subsequent
calls to public API functions would dereference NULL without checking. This could
cause crashes if the API is used incorrectly or after deinitialization.

Fix: Add NULL checks for p at the start of all public API functions:
- audioplayer_load: return AUDIOPLAYER_ERR_OUT_OF_MEM
- audioplayer_unload: no-op return
- audioplayer_is_finished: return false
- audioplayer_play: return AUDIOPLAYER_ERR_OUT_OF_MEM
- audioplayer_toggle: return AUDIOPLAYER_ERR_OUT_OF_MEM
- audioplayer_seek: return AUDIOPLAYER_ERR_OUT_OF_MEM
- audioplayer_get_*: return safe zero/false values

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
