### PR TITLE
Fix/cover art buffer leaks

### DIFF
--- a/src/menu/id3_parser.c
+++ b/src/menu/id3_parser.c
@@ -303,7 +303,7 @@ static bool parse_id3v2(const uint8_t *buf, size_t buf_size, id3_metadata_t *met
         }
 
         pos += frame_hdr_size;
-        if (frame_size == 0 || pos + frame_size > tag_size) break;
+        if (frame_size == 0 || pos > tag_size || frame_size > tag_size - pos) break;
 
         const uint8_t *data = &buf[pos];
         size_t data_len = frame_size;

--- a/src/menu/jpeg_decoder.c
+++ b/src/menu/jpeg_decoder.c
@@ -7,3 +7,15 @@
 #include <stdlib.h>
 #include <libdragon.h>
 #include "jpeg_decoder.h"
+
+jpeg_err_t jpeg_decoder_start_mem (void *buf, size_t buf_size, int max_width, int max_height, jpeg_callback_t *callback, void *callback_data) {
+    free(buf);
+    if (callback) callback(JPEG_ERR_INT, NULL, callback_data);
+    return JPEG_ERR_INT;
+}
+
+void jpeg_decoder_abort (void) {}
+
+float jpeg_decoder_get_progress (void) { return 0.0f; }
+
+void jpeg_decoder_poll (void) {}

--- a/src/menu/jpeg_decoder.h
+++ b/src/menu/jpeg_decoder.h
@@ -6,6 +6,9 @@
 #ifndef JPEG_DECODER_H__
 #define JPEG_DECODER_H__
 
+#include <stddef.h>
+#include <surface.h>
+
 /** @brief JPEG decoder error codes. */
 typedef enum {
     JPEG_OK             =  0,
@@ -15,5 +18,12 @@ typedef enum {
     JPEG_ERR_NO_FILE    = -4,
     JPEG_ERR_BAD_FILE   = -5,
 } jpeg_err_t;
+
+typedef void jpeg_callback_t (jpeg_err_t err, surface_t *decoded_image, void *callback_data);
+
+jpeg_err_t jpeg_decoder_start_mem (void *buf, size_t buf_size, int max_width, int max_height, jpeg_callback_t *callback, void *callback_data);
+void jpeg_decoder_abort (void);
+float jpeg_decoder_get_progress (void);
+void jpeg_decoder_poll (void);
 
 #endif /* JPEG_DECODER_H__ */

--- a/src/menu/views/music_player.c
+++ b/src/menu/views/music_player.c
@@ -315,6 +315,7 @@ static bool try_cover_path (const char *path, int max_size) {
         //     free(buf);
         //     return false;
         // }
+        // return true;
         free(buf);
         return false;
     } else {

--- a/src/menu/views/music_player.c
+++ b/src/menu/views/music_player.c
@@ -3,7 +3,7 @@
 #include <math.h>
 #include <sys/stat.h>
 
-//#include "../jpeg_decoder.h"
+#include "../jpeg_decoder.h"
 #include "../audio_player.h"
 #include "../png_decoder.h"
 #include "../sound.h"
@@ -112,7 +112,7 @@ static void try_next_cover_source(void);
 
 /** Cancel any in-progress cover art decode. */
 static void abort_cover_decode (void) {
-    //if (cover_state == COVER_LOADING_JPEG) jpeg_decoder_abort();
+    if (cover_state == COVER_LOADING_JPEG) jpeg_decoder_abort();
     if (cover_state == COVER_LOADING_PNG) png_decoder_abort();
     cover_state = COVER_IDLE;
 }
@@ -246,19 +246,19 @@ static bool png_dimensions_ok (const char *path, int max_dim) {
     return (w <= max_dim && h <= max_dim);
 }
 
-// static void cover_art_cb (jpeg_err_t err, surface_t *image, void *data) {
-//     cover_state = COVER_IDLE;
-//     if (err == JPEG_OK && image) {
-//         if (cover_image) {
-//             surface_free(cover_image);
-//             free(cover_image);
-//         }
-//         cover_image = image;
-//         cover_cache_blit_params();
-//     } else {
-//         try_next_cover_source();
-//     }
-// }
+static void cover_art_cb (jpeg_err_t err, surface_t *image, void *data) {
+    cover_state = COVER_IDLE;
+    if (err == JPEG_OK && image) {
+        if (cover_image) {
+            surface_free(cover_image);
+            free(cover_image);
+        }
+        cover_image = image;
+        cover_cache_blit_params();
+    } else {
+        try_next_cover_source();
+    }
+}
 
 static void cover_art_png_cb (png_err_t err, surface_t *image, void *data) {
     cover_state = COVER_IDLE;
@@ -307,17 +307,14 @@ static bool try_cover_path (const char *path, int max_size) {
     if (!buf) return false;
 
     if (is_jpeg) {
-        // cover_state = COVER_LOADING_JPEG;
-        // jpeg_err_t err = jpeg_decoder_start_mem(buf, buf_size, max_size, max_size,
-        //                                         cover_art_cb, NULL);
-        // if (err != JPEG_OK) {
-        //     cover_state = COVER_IDLE;
-        //     free(buf);
-        //     return false;
-        // }
-        // return true;
-        free(buf);
-        return false;
+        cover_state = COVER_LOADING_JPEG;
+        jpeg_err_t err = jpeg_decoder_start_mem(buf, buf_size, max_size, max_size,
+                                               cover_art_cb, NULL);
+        if (err != JPEG_OK) {
+            cover_state = COVER_IDLE;
+            free(buf);
+            return false;
+        }
     } else {
         cover_state = COVER_LOADING_PNG;
         png_err_t err = png_decoder_start_mem(buf, buf_size, max_size, max_size,
@@ -513,11 +510,11 @@ static void load_cover_art (path_t *directory) {
                 cover_state = COVER_LOADING_PNG;
                 started = (png_decoder_start_mem(buf, buf_size, max_size, max_size,
                                                  cover_art_png_cb, NULL) == PNG_OK);
-            } // else {
-            //     cover_state = COVER_LOADING_JPEG;
-            //     started = (jpeg_decoder_start_mem(buf, buf_size, max_size, max_size,
-            //                                       cover_art_cb, NULL) == JPEG_OK);
-            // }
+            } else {
+                cover_state = COVER_LOADING_JPEG;
+                started = (jpeg_decoder_start_mem(buf, buf_size, max_size, max_size,
+                                                  cover_art_cb, NULL) == JPEG_OK);
+            }
 
             if (started) return;
             cover_state = COVER_IDLE;
@@ -1005,7 +1002,9 @@ static void draw (menu_t *menu, surface_t *d) {
         // float progress = (cover_state == COVER_LOADING_JPEG)
         //                ? jpeg_decoder_get_progress()
         //                : png_decoder_get_progress();
-        float progress = png_decoder_get_progress();
+        float progress = (cover_state == COVER_LOADING_JPEG)
+                       ? jpeg_decoder_get_progress()
+                       : png_decoder_get_progress();
         char buf[16];
         snprintf(buf, sizeof(buf), "%d%%", (int)(progress * 100));
         rdpq_text_printn(

--- a/src/menu/views/music_player.c
+++ b/src/menu/views/music_player.c
@@ -312,14 +312,18 @@ static bool try_cover_path (const char *path, int max_size) {
         //                                         cover_art_cb, NULL);
         // if (err != JPEG_OK) {
         //     cover_state = COVER_IDLE;
-            return false;
+        //     free(buf);
+        //     return false;
         // }
+        free(buf);
+        return false;
     } else {
         cover_state = COVER_LOADING_PNG;
         png_err_t err = png_decoder_start_mem(buf, buf_size, max_size, max_size,
                                               cover_art_png_cb, NULL);
         if (err != PNG_OK) {
             cover_state = COVER_IDLE;
+            free(buf);
             return false;
         }
     }
@@ -516,6 +520,7 @@ static void load_cover_art (path_t *directory) {
 
             if (started) return;
             cover_state = COVER_IDLE;
+            free(buf);
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add jpeg_callback_t, jpeg_decoder_start_mem, jpeg_decoder_abort,
jpeg_decoder_get_progress, and jpeg_decoder_poll stubs that return
JPEG_ERR_INT / no-op until a real implementation is available.

Uncomment all JPEG code paths in music_player.c (cover_art_cb,
abort_cover_decode, try_cover_path, load_cover_art, progress display)
so the code compiles and gracefully falls back via the callback on failure.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
