### PR TITLE
Use banked SRAM for Game Boy emulator saves instead of FLASHRAM

### DIFF
--- a/src/menu/cart_load.c
+++ b/src/menu/cart_load.c
@@ -255,14 +255,19 @@ cart_load_err_t cart_load_emulator (menu_t *menu, cart_load_emu_type_t emu_type,
         case CART_LOAD_EMU_TYPE_GAMEBOY:
             emu_section = "gb";
             default_rom_filename = "gb.v64";
-            // TODO: Saves might be less problematic by using the FAKE type.
-            save_type = FLASHCART_SAVE_TYPE_FLASHRAM_1MBIT; //FLASHCART_SAVE_TYPE_FLASHRAM_FAKE;
+            // Banked SRAM, not FLASHRAM: gb64 supports both (SVID SaveTypeSRAM3X), but as
+            // FLASHRAM it reaches the save through osFlashInit's chip-id detection and the
+            // flash command protocol, and on an SC64 in a ModRetro M64 those reads returned
+            // nothing -- a correctly formatted save booted as if absent, and an in-game save
+            // reported success and was gone on relaunch. Banked SRAM is a plain PI DMA, the
+            // same access other cores' saves already use, and works on the same hardware.
+            save_type = FLASHCART_SAVE_TYPE_SRAM_BANKED;
             break;
         case CART_LOAD_EMU_TYPE_GAMEBOY_COLOR:
             emu_section = "gbc";
             default_rom_filename = "gbc.v64";
-            // TODO: Saves might be less problematic by using the FAKE type.
-            save_type = FLASHCART_SAVE_TYPE_FLASHRAM_1MBIT; //FLASHCART_SAVE_TYPE_FLASHRAM_FAKE;
+            // Same as GAMEBOY above.
+            save_type = FLASHCART_SAVE_TYPE_SRAM_BANKED;
             break;
         case CART_LOAD_EMU_TYPE_SEGA_GENERIC_8BIT:
             emu_section = "sega8bit";


### PR DESCRIPTION
This resolves the TODO in `cart_load_emulator()` ("Saves might be less problematic by using the FAKE type") with hardware evidence: flash was indeed the problematic path.

## What was observed

On an SC64 running in a ModRetro M64, gb64 saves configured as `FLASHCART_SAVE_TYPE_FLASHRAM_1MBIT` failed silently in both directions:

- a correctly formatted save file loaded by the menu booted in gb64 as if no save existed;
- an in-game save reported success and was gone on relaunch.

The save file itself was ruled out: a converter building gb64's own layout (settings header at 0, cart RAM at 0x80, offsets pinned by static asserts against gb64's headers) round-trips the RAM section byte-identical. What fails is the access path: as FLASHRAM, gb64 reaches the save through `osFlashInit`'s chip-id detection and the flash command protocol, and the M64's handling of flash emulation returned nothing readable. As banked SRAM the same data moves over plain PI DMA — the access other cores' saves already use — and save/load works on the same hardware, tested across power cycles.

## What this changes

Two save-type assignments (GB and GBC emulator launches) from `FLASHRAM_1MBIT` to `SRAM_BANKED` (96 KB). gb64 supports this natively — its SVID save-type setting has a `SaveTypeSRAM3X` value with the settings block and cart RAM at the same offsets.

## Caveats worth weighing

- gb64 core ROMs must carry a matching SVID (`SaveTypeSRAM3X`); a core stamped for flash will look for its save in the flash address space regardless of what the menu armed. If you'd prefer, I can extend the PR to note this in the emulator-support docs.
- Existing users with working FLASHRAM-format `.sav` files (128 KB) will not match `SAVE_SIZE[SRAM_BANKED]` (96 KB) after this change and would need converting. On original hardware flash may well work — the failure was observed on a clone console — so if you'd rather gate this per-cart or per-setting instead of switching the default, happy to rework it that way.