### PR TITLE
Fix wav64 resource leak when SFX/BGM disabled via settings

### DIFF
--- a/src/menu/sound.c
+++ b/src/menu/sound.c
@@ -18,6 +18,8 @@ static wav64_t sfx_cursor, sfx_error, sfx_enter, sfx_exit, sfx_setting, bgm;
 static bool sound_initialized = false;
 static bool sfx_enabled = false;
 static bool bgm_enabled = false;
+static bool sfx_opened = false;
+static bool bgm_opened = false;
 
 /**
  * @brief Reconfigure the sound system with the specified frequency.
@@ -84,6 +86,7 @@ void sound_init_sfx (void) {
     wav64_open(&sfx_enter, "rom:/enter.wav64");
     wav64_open(&sfx_error, "rom:/error.wav64");
     sfx_enabled = true;
+    sfx_opened = true;
 }
 
 /**
@@ -93,6 +96,7 @@ void sound_init_bgm (void) {
     wav64_open(&bgm, "rom:/bgm.wav64");
     wav64_set_loop(&bgm, true);
     mixer_ch_set_vol(SOUND_BGM_CHANNEL, 0.1f, 0.1f);
+    bgm_opened = true;
 }
 
 /**
@@ -152,15 +156,17 @@ void sound_play_effect(sound_effect_t sfx) {
  */
 void sound_deinit (void) {
     if (sound_initialized) {
-        if (sfx_enabled) {
+        if (sfx_opened) {
             wav64_close(&sfx_cursor);
             wav64_close(&sfx_exit);
             wav64_close(&sfx_setting);
             wav64_close(&sfx_enter);
             wav64_close(&sfx_error);
+            sfx_opened = false;
         }
-        if (bgm_enabled) {
+        if (bgm_opened) {
             wav64_close(&bgm);
+            bgm_opened = false;
         }
         mixer_close();
         audio_close();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
sound_init_sfx()/sound_init_bgm() open their wav64 resources unconditionally and are always called once at startup regardless of user settings. The enabled flags (sfx_enabled/bgm_enabled) are then set afterward via sound_use_sfx()/sound_use_bgm() based on menu->settings, which can turn them false even though the resources are already open.

sound_deinit() gated its wav64_close() calls on these same enabled flags, so disabling SFX or BGM in settings caused the already-open resources to never be closed on reconfigure (MP3 playback) or shutdown.

Fix: add separate sfx_opened/bgm_opened flags that track actual resource state independently of the user-facing enabled flags, and close based on those instead.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
