### PR TITLE
Fix/emulator rom offset validation

### DIFF
--- a/src/menu/cart_load.c
+++ b/src/menu/cart_load.c
@@ -310,7 +310,8 @@ cart_load_err_t cart_load_emulator (menu_t *menu, cart_load_emu_type_t emu_type,
             if (rom_offset_str) {
                 char *end = NULL;
                 unsigned long parsed = strtoul(rom_offset_str, &end, 0);
-                if (end != rom_offset_str && *end == '\0') {
+                // Reject offsets that would make (MiB(64) - rom_offset) wrap in the flashcart loaders.
+                if (end != rom_offset_str && *end == '\0' && parsed < MiB(64)) {
                     emulated_rom_offset = (uint32_t) parsed;
                 }
             }

--- a/src/menu/cart_load.c
+++ b/src/menu/cart_load.c
@@ -310,7 +310,9 @@ cart_load_err_t cart_load_emulator (menu_t *menu, cart_load_emu_type_t emu_type,
             if (rom_offset_str) {
                 char *end = NULL;
                 unsigned long parsed = strtoul(rom_offset_str, &end, 0);
-                // Reject offsets that would make (MiB(64) - rom_offset) wrap in the flashcart loaders.
+                // flashcart_load_file() writes to ROM_ADDRESS + rom_offset within the primary
+                // 64MB SDRAM window on every flashcart (no extended-region support in load_file),
+                // so reject offsets that would make (MiB(64) - rom_offset) wrap.
                 if (end != rom_offset_str && *end == '\0' && parsed < MiB(64)) {
                     emulated_rom_offset = (uint32_t) parsed;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR just describes a potential fix. We need to actually fix the underlying issue!

rom_offset is parsed from an untrusted, user-editable INI file and cast
directly to uint32_t. Flashcart loaders (sc64, 64drive, ed64 v/x-series)
compute MiB(64) - rom_offset for a bounds check; if rom_offset exceeds
MiB(64) this subtraction wraps to a huge value, making the check pass
when it shouldn't and leading to an out-of-bounds SDRAM write via
ROM_ADDRESS + rom_offset.

Fix: reject any parsed rom_offset >= MiB(64) at the point of parsing,
before it reaches the flashcart loaders.

load_file() (used for the rom_offset path) has no extended-addressing
support in any flashcart implementation; it only ever writes within the
primary 64MB SDRAM window. The 78MB ceiling only applies to full-ROM
loading via load_rom(), a separate code path that doesn't use rom_offset.



## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
