### PR TITLE
Warn before loading a ROM requiring an Expansion Pak that isn't present

### DIFF
--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -10,6 +10,7 @@
 
 static bool show_extra_info_message = false;
 static bool show_advanced_info_message = false;
+static bool show_expansion_pak_warning = false;
 static component_boxart_t *boxart;
 static char *rom_filename = NULL;
 
@@ -546,13 +547,33 @@ static int get_rom_clear_rdram_current_selection (menu_t *menu) {
         (void *) (menu->load.rom_info.settings.clear_rdram_enabled ? true : false));
 }
 
+static bool rom_requires_missing_expansion_pak (menu_t *menu) {
+    return (menu->load.rom_info.features.expansion_pak == EXPANSION_PAK_REQUIRED) && !is_memory_expanded();
+}
+
 static void process (menu_t *menu) {
     if (ui_components_context_menu_process(menu, &options_context_menu)) {
         return;
     }
 
+    if (show_expansion_pak_warning) {
+        if (menu->actions.enter) {
+            show_expansion_pak_warning = false;
+            menu->load_pending.rom_file = true;
+        } else if (menu->actions.back) {
+            show_expansion_pak_warning = false;
+            sound_play_effect(SFX_EXIT);
+        }
+        return;
+    }
+
     if (menu->actions.enter) {
-        menu->load_pending.rom_file = true;
+        if (rom_requires_missing_expansion_pak(menu)) {
+            show_expansion_pak_warning = true;
+            sound_play_effect(SFX_ERROR);
+        } else {
+            menu->load_pending.rom_file = true;
+        }
     } else if (menu->actions.back) {
         sound_play_effect(SFX_EXIT);
         menu->next_mode = MENU_MODE_BROWSER;
@@ -711,6 +732,15 @@ static void draw (menu_t *menu, surface_t *d) {
             );
         }
 
+        if (show_expansion_pak_warning) {
+            ui_components_messagebox_draw(
+                "This ROM requires an Expansion Pak\n"
+                "which was not detected.\n\n"
+                "It may not run correctly without one.\n\n"
+                "A: Continue anyway, B: Cancel\n"
+            );
+        }
+
         ui_components_context_menu_draw(&options_context_menu);
 #ifdef FEATURE_AUTOLOAD_ROM_ENABLED
     }
@@ -850,6 +880,7 @@ void view_load_rom_init (menu_t *menu) {
     if (show_advanced_info_message) {
         show_advanced_info_message = false;
     }
+    show_expansion_pak_warning = false;
 
     debugf("Load ROM: loading ROM info from %s\n", path_get(menu->load.rom_path));
     rom_err_t err = rom_config_load(menu->load.rom_path, &menu->load.rom_info);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
cart_load_n64_rom_and_save() never checked whether a ROM flagged EXPANSION_PAK_REQUIRED actually has an Expansion Pak available, unlike the 64DD IPL path which already blocks on is_memory_expanded(). This let users boot ROMs that would misbehave or crash without any indication why.

Add a confirmation dialogue in the ROM info view: pressing A when the ROM requires a missing Expansion Pak shows a warning with the option to continue anyway (A) or cancel (B), mirroring the existing show_message modal pattern used elsewhere in the menu.

## Motivation and Context
<!--- What does this sample do? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here  -->

## How Has This Been Tested?
<!-- (if applicable) -->
<!--- Please describe in detail how you tested your sample/changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
