### PR TITLE
Improve Expansion Pak Wording

### DIFF
--- a/src/menu/views/load_rom.c
+++ b/src/menu/views/load_rom.c
@@ -189,9 +189,9 @@ static const char *format_rom_expansion_pak_info (rom_expansion_pak_t expansion_
     switch (expansion_pak_info) {
         case EXPANSION_PAK_REQUIRED: return "Required";
         case EXPANSION_PAK_RECOMMENDED: return "Recommended";
-        case EXPANSION_PAK_SUGGESTED: return "Suggested";
+        case EXPANSION_PAK_SUGGESTED: return "Enhanced";
         case EXPANSION_PAK_FAULTY: return "May require ROM patch";
-        default: return "Not required";
+        default: return "Not used";
     }
 }
 


### PR DESCRIPTION
## Description

Clarifies the Expansion Pak status wording shown on the ROM information screen.

This changes the displayed labels as follows:

- `Suggested` → `Enhanced`
- `Not required` → `Not used`

No ROM database values, Expansion Pak detection logic, or boot behavior are changed.

## Motivation and Context

The current wording can be misleading when compared with the underlying ROM metadata.

ROMs marked with the database flag `FEAT_EXP_PAK_ENHANCED` are currently mapped internally to `EXPANSION_PAK_SUGGESTED`, which is then displayed as `Suggested`. Displaying this as `Enhanced` more accurately reflects the database metadata.

Likewise, `Not used` is clearer than `Not required` for titles that do not use the Expansion Pak.

Closes #310.

## How Has This Been Tested?

The change is limited to two user-facing strings in `format_rom_expansion_pak_info()` and does not modify ROM metadata handling, Expansion Pak detection, or ROM loading behavior.

The repository's automated build workflow will validate the change when the PR is submitted.

## Screenshots

Not applicable.

## Types of changes

- [x] Improvement (non-breaking change that adds a new feature)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (breaking change)
- [ ] Documentation Improvement
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

You agree with the license terms and that other license types may be granted with permission of the original `N64FlashcartMenu` project license holders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Changed existing Expansion Pak display labels to be clearer to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->